### PR TITLE
PLT-4430 improve channel switching

### DIFF
--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -89,7 +89,9 @@
           '200':
             description: The list of channels
             schema:
-              $ref: '#/definitions/ChannelList'
+              type: array
+              items:
+                $ref: '#/definitions/Channel'
           '403':
             description: User does not belong to the team
           '500':
@@ -111,11 +113,37 @@
         '200':
           description: The list of channels
           schema:
-            $ref: '#/definitions/ChannelList'
+            type: array
+            items:
+              $ref: '#/definitions/Channel'
         '403':
           description: User does not belong to the team
         '500':
           description: Could not retrieve the user channels
+
+  '/teams/{team_id}/channels/unread':
+    get:
+      tags:
+        - channels
+      summary: Get unread and mention count for channels the user is part of if there are any
+      description: Get a list of unread and mention count for the channels the user belongs to by team ID.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team ID of the unread and mentions count of the channels to return
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The list of member unread messages and mention counts
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ChannelMember'
+        '403':
+          description: User does not belong to the team
+        '500':
+          description: Could not retrieve the user unread messages and mention counts
 
   '/teams/{team_id}/channels/{channel_id}':
     get:

--- a/source/definitions.yaml
+++ b/source/definitions.yaml
@@ -141,18 +141,6 @@ definitions:
       last_update_at:
         type: integer
 
-  ChannelList:
-    type: object
-    properties:
-      channels: 
-        type: array
-        items:
-          $ref: '#/definitions/Channel'
-      members:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/ChannelMember'
-
   ChannelData:
     type: object
     properties:


### PR DESCRIPTION
This changes the API's to return only the channels for `getChannels` and `getMoreChannels` and adds a new API `/channels/unread` that returns only the unread messages and mentions count for the channels if there are any
