### PR TITLE
API endpoint to get channel members by IDs.

### DIFF
--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -343,6 +343,39 @@
         '500':
           description: Could not retrieve the channel member, the user is not a member of the channel or the channel does not belong to the team
 
+  '/teams/{team_id}/channels/{channel_id}/members/ids':
+      post:
+        tags:
+          - channels
+        summary: Get channel members by IDs
+        description: Get a map of channel member objects for the specified channel and user IDs.
+        parameters:
+          - name: team_id
+            in: path
+            description: Team ID of the member to return
+            required: true
+            type: string
+          - name: channel_id
+            in: path
+            description: The channel ID
+            required: true
+            type: string
+          - in: body
+            name: body
+            description: A list of user IDs
+            required: true
+            schema:
+              type: array
+              items:
+                type: string
+        responses:
+          '200':
+            description: Members retreived successfully
+            schema:
+              type: object
+              additionalProperties:
+                $ref: "#/definitions/ChannelMember"
+
   '/teams/{team_id}/channels/autocomplete':
     get:
       tags:

--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -348,7 +348,7 @@
         tags:
           - channels
         summary: Get channel members by IDs
-        description: Get a map of channel member objects for the specified channel and user IDs.
+        description: Get an array of channel member objects for the specified channel and user IDs.
         parameters:
           - name: team_id
             in: path
@@ -372,7 +372,7 @@
           '200':
             description: Members retreived successfully
             schema:
-              type: object
+              type: array
               additionalProperties:
                 $ref: "#/definitions/ChannelMember"
 

--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -352,7 +352,7 @@
         parameters:
           - name: team_id
             in: path
-            description: Team ID of the member to return
+            description: Team ID for the corresponding channel
             required: true
             type: string
           - name: channel_id


### PR DESCRIPTION
The purpose of this is to make it possible to find out the roles of the members of a channel.

This will partially enable PLT-5049.

This is designed to be analogous to the Team Members By Ids API endpoint.