### PR TITLE
[WIP] PLT-4176: Add Documentation for Pinned Posts

### DIFF
--- a/source/v3/channels.yaml
+++ b/source/v3/channels.yaml
@@ -239,6 +239,26 @@
         '500':
           description: Could not retrieve the channel members
 
+  '/teams/{team_id}/channels/pinned':
+    get:
+      tags:
+        - channels
+      summary: Get a channel's pinned posts
+      description: Get a list of pinned posts for channel.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team ID to get the pinned posts for
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The list of channel pinned posts
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PostList'
+
   '/teams/{team_id}/channels/{channel_id}':
     get:
       tags:

--- a/source/v3/definitions.yaml
+++ b/source/v3/definitions.yaml
@@ -188,6 +188,8 @@ definitions:
           type: string
       pending_post_id:
         type: string
+      is_pinned:
+        type: number
 
   PostList:
     type: object

--- a/source/v3/posts.yaml
+++ b/source/v3/posts.yaml
@@ -115,6 +115,60 @@
           schema:
             $ref: "#/definitions/Post"
 
+  '/teams/{team_id}/channels/{channel_id}/posts/{post_id}/pin':
+    post:
+      tags:
+        - posts
+      summary: Pin a post
+      parameters:
+        - name: team_id
+          in: path
+          description: The team ID.
+          required: true
+          type: string
+        - name: channel_id
+          in: path
+          description: The channel ID.
+          required: true
+          type: string
+        - name: post_id
+          in: path
+          description: The post ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Post pinned successfully
+          schema:
+            $ref: "#/definitions/Post"
+
+  '/teams/{team_id}/channels/{channel_id}/posts/{post_id}/unpin':
+    post:
+      tags:
+        - posts
+      summary: Unpin a post
+      parameters:
+        - name: team_id
+          in: path
+          description: The team ID.
+          required: true
+          type: string
+        - name: channel_id
+          in: path
+          description: The channel ID.
+          required: true
+          type: string
+        - name: post_id
+          in: path
+          description: The post ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Post unpinned successfully
+          schema:
+            $ref: "#/definitions/Post"
+
   '/teams/{team_id}/channels/{channel_id}/posts/page/{offset}/{limit}':
     get:
       tags:


### PR DESCRIPTION
This PR adds the documentation for pinned posts, according to [mattermost/platform/pull/4217](https://github.com/mattermost/platform/pull/4217).