### PR TITLE
Fix websocket endpoint path

### DIFF
--- a/source/introduction.yaml
+++ b/source/introduction.yaml
@@ -142,7 +142,7 @@ tags:
     description: |
       In addition to the HTTP RESTful web service, Mattermost also offers a WebSocket event delivery system and some API functionality.
 
-      To connect to the WebSocket follow the standard opening handshake as [defined by the RFC specification](https://tools.ietf.org/html/rfc6455#section-1.3) to the `/api/v3/websocket` endpoint of Mattermost.
+      To connect to the WebSocket follow the standard opening handshake as [defined by the RFC specification](https://tools.ietf.org/html/rfc6455#section-1.3) to the `/api/v3/users/websocket` endpoint of Mattermost.
 
       #### Authentication
 


### PR DESCRIPTION
In the implementation, the endpoint for the websocket is `/api/v3/users/websocket` (see [source](https://github.com/mattermost/platform/blob/master/api/websocket.go#L20)). This fixes the docs to match the current implementation.