### PR TITLE
Fixed typo and swagger errors

### DIFF
--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -407,6 +407,8 @@
             description: Members retreived successfully
             schema:
               type: array
+              items:
+                $ref: "#/definitions/ChannelMember"
               additionalProperties:
                 $ref: "#/definitions/ChannelMember"
 

--- a/source/channels.yaml
+++ b/source/channels.yaml
@@ -404,7 +404,7 @@
                 type: string
         responses:
           '200':
-            description: Members retreived successfully
+            description: Members retrieved successfully
             schema:
               type: array
               items:
@@ -469,7 +469,7 @@
           type: string
       responses:
         '200':
-          description: Autocomplete channels retreived successfully
+          description: Autocomplete channels retrieved successfully
           schema:
             type: array
             items:
@@ -500,7 +500,7 @@
                 type: string
       responses:
         '200':
-          description: Channels retreived successfully
+          description: Channels retrieved successfully
           schema:
             type: array
             items:

--- a/source/posts.yaml
+++ b/source/posts.yaml
@@ -54,7 +54,7 @@
           type: integer
       responses:
         '200':
-          description: Posts retreived successfully
+          description: Posts retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 
@@ -143,7 +143,7 @@
           type: string
       responses:
         '200':
-          description: Post retreived successfully
+          description: Post retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 
@@ -171,7 +171,7 @@
           type: string
       responses:
         '200':
-          description: Post retreived successfully
+          description: Post retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 
@@ -198,7 +198,7 @@
           type: string
       responses:
         '200':
-          description: Post retreived successfully
+          description: Post retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 
@@ -269,7 +269,7 @@
           type: string
       responses:
         '200':
-          description: Posts retreived successfully
+          description: Posts retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 
@@ -307,7 +307,7 @@
           type: string
       responses:
         '200':
-          description: Posts retreived successfully
+          description: Posts retrieved successfully
           schema:
             $ref: "#/definitions/PostList"
 

--- a/source/teams.yaml
+++ b/source/teams.yaml
@@ -100,7 +100,7 @@
           type: integer
       responses:
         '200':
-          description: Members retreived successfully
+          description: Members retrieved successfully
           schema:
             type: array
             items:
@@ -125,7 +125,7 @@
           type: string
       responses:
         '200':
-          description: Member retreived successfully
+          description: Member retrieved successfully
           schema:
             $ref: "#/definitions/TeamMember"
 
@@ -151,7 +151,7 @@
               type: string
       responses:
         '200':
-          description: Members retreived successfully
+          description: Members retrieved successfully
           schema:
             type: array
             items:

--- a/source/teams.yaml
+++ b/source/teams.yaml
@@ -154,6 +154,8 @@
           description: Members retreived successfully
           schema:
             type: array
+            items:
+              $ref: "#/definitions/TeamMember"
             additionalProperties:
               $ref: "#/definitions/TeamMember"
 

--- a/source/teams.yaml
+++ b/source/teams.yaml
@@ -299,5 +299,5 @@
         '200':
           description: An array with the commands
           schema:
-            $ref: "#/definitions/Commands"
+            $ref: "#/definitions/Command"
 

--- a/source/users.yaml
+++ b/source/users.yaml
@@ -118,7 +118,7 @@
           type: integer
       responses:
         '200':
-          description: Users retreived successfully
+          description: Users retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -187,7 +187,7 @@
                 description: Set this to `true` if you would like to include inactive users in your search.
       responses:
         '200':
-          description: Profiles retreived successfully
+          description: Profiles retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -246,7 +246,7 @@
               type: string
       responses:
         '200':
-          description: Profiles retreived successfully
+          description: Profiles retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -281,7 +281,7 @@
           type: integer
       responses:
         '200':
-          description: Profiles retreived successfully
+          description: Profiles retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -316,7 +316,7 @@
           type: integer
       responses:
         '200':
-          description: Profiles retreived successfully
+          description: Profiles retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -501,7 +501,7 @@
           type: string
       responses:
         '200':
-          description: Autocomplete users retreived successfully
+          description: Autocomplete users retrieved successfully
           schema:
             type: array
             items:
@@ -526,7 +526,7 @@
           type: string
       responses:
         '200':
-          description: Autocomplete users retreived successfully
+          description: Autocomplete users retrieved successfully
           schema:
             type: object
             additionalProperties:
@@ -556,7 +556,7 @@
           type: string
       responses:
         '200':
-          description: Autocomplete users retreived successfully
+          description: Autocomplete users retrieved successfully
           schema:
             type: object
             additionalProperties:


### PR DESCRIPTION
- Fixed the typo from retreived to retrieved
- Fixed Command typo in the `teams.yaml` to match the Command definition in the `definitions.yaml` 
- Added items for arrays to fix the swagger error when loading the yaml file in `http://editor.swagger.io/`

