### PR TITLE
Documentation for APIv4: GET /teams/{team_id}/members

### DIFF
--- a/source/v4/teams.yaml
+++ b/source/v4/teams.yaml
@@ -95,7 +95,7 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
-
+          
   '/teams/{team_id}/members':
     get:
       tags:

--- a/source/v4/teams.yaml
+++ b/source/v4/teams.yaml
@@ -100,9 +100,9 @@
     get:
       tags:
         - teams
-      summary: Get a page of a list of team members based on query string parameters - team id, page and per page.
+      summary: Get team members
       description: |
-        Get team members on the system.
+        Get a page team members list based on query string parameters - team id, page and per page.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
       parameters:

--- a/source/v4/teams.yaml
+++ b/source/v4/teams.yaml
@@ -96,6 +96,45 @@
         '403':
           $ref: '#/responses/Forbidden'
 
+  '/teams/{team_id}/members':
+    get:
+      tags:
+        - teams
+      summary: Get a page of a list of team members based on query string parameters - team id, page and per page.
+      description: |
+        Get team members on the system.
+        ##### Permissions
+        Must be authenticated and have the `view_team` permission.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team GUID
+          required: true
+          type: string
+        - name: page
+          in: query
+          description: The page to select.
+          default: "0"
+          type: string
+        - name: per_page
+          in: query
+          description: The number of users per page.
+          default: "60"
+          type: string
+      responses:
+        '201':
+          description: Team members retrieval successful
+          schema:
+            $ref: '#/definitions/TeamMembers'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+
   '/teams/{team_id}/members/{user_id}':
     get:
       tags:


### PR DESCRIPTION
This is the documentation for endpoint APIv4: GET /teams/{team_id}/members

[Github issue: 5409](https://github.com/mattermost/platform/issues/5409)