### PR TITLE
APIv4 PUT /posts/{post_id}/patch

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -123,6 +123,47 @@
         '403':
           $ref: '#/responses/Forbidden'
 
+  '/posts/{post_id}/patch':
+    put:
+      tags:
+        - posts
+      summary: Patch a post
+      description: |
+        Partially update a post by providing only the fields you want to update. Omitted fields will not be updated. The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+        ##### Permissions
+        Must have the `edit_post` permission.
+      parameters:
+        - name: post_id
+          in: path
+          description: Post GUID
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Post object that is to be updated
+          required: true
+          schema:
+            type: object
+            properties:
+              is_pinned:
+                type: boolean
+              message:
+                type: string
+              file_ids:
+                 type: array
+              has_reactions:
+                type: boolean
+      responses:
+        '200':
+          description: post patch successful
+          schema:
+            $ref: '#/definitions/Post'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
 
   '/posts/{post_id}/thread':
     get:


### PR DESCRIPTION
This is endpoint documentation for APIv4 PUT /posts/{post_id}/patch.