### PR TITLE
APIv4 get /channels/{channel_id}/pinned

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -265,6 +265,30 @@
         '403':
           $ref: '#/responses/Forbidden'
 
+  '/channels/{channel_id}/pinned':
+    get:
+      tags:
+        - channels
+      summary: Get a channel's pinned posts
+      description: Get a list of pinned posts for channel.
+      parameters:
+        - name: channel_id
+          in: path
+          description: Channel GUID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The list of channel pinned posts
+          schema:
+            $ref: '#/definitions/PostList'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
   '/teams/{team_id}/channels':
     get:
       tags:


### PR DESCRIPTION
This is endpoint documentation for `APIv4 get /channels/{channel_id}/pinned`.