### PR TITLE
APIv4 post /teams/search

### DIFF
--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -227,6 +227,45 @@
         '404':
           $ref: '#/responses/NotFound'
 
+  '/teams/search':
+    post:
+      tags:
+        - teams
+      summary: Search teams
+      description: |
+        Search teams based on search term provided in the request body.
+        ##### Permissions
+        Logged in user only shows open teams
+        Logged in user with "manage_system" permission shows all teams
+      parameters:
+        - in: body
+          name: body
+          description: Search criteria
+          required: true
+          schema:
+            type: object
+            required:
+              - term
+            properties:
+              term:
+                description: The search term to match against the name or display name of teams
+                type: string
+      responses:
+        '201':
+          description: Teams search successful
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Team'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+
   '/teams/name/{name}/exists':
     get:
       tags:


### PR DESCRIPTION
This is endpoint documentation for `APIv4 post /teams/search`.