### PR TITLE
APIv4 GET /posts/{post_id}/reactions

### DIFF
--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -1,0 +1,28 @@
+  '/posts/{post_id}/reactions':
+    get:
+      tags:
+        - reactions
+      summary: Get a list of reactions to a post
+      description: |
+        Get a list of reactions made by all users to a given post.
+        ##### Permissions
+        Must have `read_channel` permission for the channel the post is in.
+      parameters:
+        - name: post_id
+          in: path
+          description: ID of a post
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List reactions retrieve successful
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Reaction"
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'


### PR DESCRIPTION
This is endpoint documentation for `APIv4 GET /posts/{post_id}/reactions`.