### PR TITLE
APIv4 POST /reactions

### DIFF
--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -1,3 +1,29 @@
+  /reactions:
+    post:
+      tags:
+        - reactions
+      summary: Create a reaction
+      description: |
+        Create a reaction.
+        ##### Permissions
+        Must have `read_channel` permission for the channel the post is in.
+      parameters:
+        - in: body
+          name: reaction
+          description: The user's reaction with its post_id, user_id, and emoji_name fields set
+          required: true
+          schema:
+            $ref: '#/definitions/Reaction'
+      responses:
+        '201':
+          description: Reaction creation successful
+          schema:
+            $ref: '#/definitions/Reaction'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '403':
+          $ref: '#/responses/Forbidden'
+
   '/posts/{post_id}/reactions':
     get:
       tags:


### PR DESCRIPTION
This is endpoint documentation for `APIv4 POST /reactions`.

Note that this PR is issued on top of [PR#211](https://github.com/mattermost/mattermost-api-reference/pull/211). (Will just rebase and fix conflict later)