### PR TITLE
status.yaml: indent path

### DIFF
--- a/v4/source/status.yaml
+++ b/v4/source/status.yaml
@@ -1,4 +1,4 @@
-/users/{user_id}/status:
+  /users/{user_id}/status:
     get:
       tags:
         - status


### PR DESCRIPTION
It looks like there is a typo in `status.yaml`. At least, my yaml parser was failing and it looks like in other files the paths are always indented 2 spaces and this one wasn't. This fixes that.