### PR TITLE
PLT-4608 Added APIs for querying job status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/brand.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/commands.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/oauth.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/jobs.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/definitions.yaml >> $(V4_YAML)
 
 	@node_modules/swagger-cli/bin/swagger.js validate $(V4_YAML)

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -1299,6 +1299,34 @@ definitions:
         type: integer
         description: The last time of update for the application
 
+  JobStatus:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The unique id of the job
+      type:
+        type: string
+        description: The type of job
+      start_at:
+        type: integer
+        description: The time at which the job was started
+      last_activity_at:
+        type: integer
+        description: The last time the job had activity
+      last_run_started_at:
+        type: integer
+        description: The last time the job started running
+      last_run_completed_at:
+        type: integer
+        description: The last time the job completed running
+      status:
+        type: string
+        description: The status of the job
+      data:
+        type: object
+        description: A freeform data field containing additional information about the progress of the job
+
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -296,6 +296,8 @@ tags:
     description: General endpoints for interating with the server, such as configuration and logging.
   - name: OAuth
     description: Endpoints for configuring and interacting with Mattermost as an OAuth 2.0 service provider.
+  - name: Jobs
+    description: Endpoints related to various background jobs that can run independent of the server.
 x-tagGroups:
   - name: Introduction
     tags:
@@ -325,6 +327,7 @@ x-tagGroups:
       - OAuth
       - SAML
       - LDAP
+      - jobs
 schemes:
   - http
   - https

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -4,9 +4,10 @@
         - jobs
       summary: Get the status of a given job.
       description: |
-          Gets the status of a single job,
-          ##### Permissions
-          Must have `manage_system` permission.
+        Gets the status of a single job.
+        __Minimum server version: 3.10__
+        ##### Permissions
+        Must have `manage_system` permission.
       parameters:
         - name: job_id
           in: path
@@ -34,6 +35,7 @@
       summary: Get the statuses of jobs of the given type.
       description: |
         Get a page of statuses of jobs of the given type. Use the query parameters to modify the behaviour of this endpoint.
+        __Minimum server version: 3.10__
         ##### Permissions
         Must have `manage_system` permission.
       parameters:

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -1,4 +1,4 @@
-  '/jobs/status/{job_id}':
+  '/jobs/{job_id}/status':
     get:
       tags:
         - jobs
@@ -25,7 +25,7 @@
         '404':
           $ref: '#/responses/NotFound'
 
-  '/jobs/statuses/{type}':
+  '/jobs/type/{type}/statuses':
     get:
       tags:
         - jobs

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -3,10 +3,10 @@
       tags:
         - jobs
       summary: Get the status of a given job.
-    description: |
-        Gets the status of a single job,
-        ##### Permissions
-        Must have `manage_system` permission.
+      description: |
+          Gets the status of a single job,
+          ##### Permissions
+          Must have `manage_system` permission.
       parameters:
         - name: job_id
           in: path
@@ -22,6 +22,8 @@
           $ref: '#/responses/BadRequest'
         '401':
           $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
         '404':
           $ref: '#/responses/NotFound'
 
@@ -61,3 +63,5 @@
           $ref: '#/responses/BadRequest'
         '401':
           $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -1,0 +1,63 @@
+  '/jobs/status/{job_id}':
+    get:
+      tags:
+        - jobs
+      summary: Get the status of a given job.
+    description: |
+        Gets the status of a single job,
+        ##### Permissions
+        Must have `manage_system` permission.
+      parameters:
+        - name: job_id
+          in: path
+          description: Job GUID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Job status retrieval successful
+          schema:
+            $ref: '#/definitions/JobStatus'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  '/jobs/statuses/{type}':
+    get:
+      tags:
+        - jobs
+      summary: Get the statuses of jobs of the given type.
+      description: |
+        Get a page of statuses of jobs of the given type. Use the query parameters to modify the behaviour of this endpoint.
+        ##### Permissions
+        Must have `manage_system` permission.
+      parameters:
+        - name: type
+          in: path
+          description: Job type
+          required: true
+          type: string
+        - name: page
+          in: query
+          description: The page to select.
+          default: "0"
+          type: string
+        - name: per_page
+          in: query
+          description: The number of jobs statuses per page.
+          default: "60"
+          type: string
+      responses:
+        '200':
+          description: Job status list retrieval successful
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/JobStatus'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'


### PR DESCRIPTION
These are the first APIs needed for the job server. As far as we have designed right now, these are the only APIs needed specifically for the job server as configuration changes will be handled by modifying config.json through existing routes.

### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6408