### PR TITLE
Fix ChannelAPI doc (channel by name)

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -642,7 +642,7 @@
             // SearchChannels
             channels, resp := Client.SearchChannels(<TEAMID>, search)
 
-  '/teams/{team_id}/channels/{channel_name}':
+  '/teams/{team_id}/channels/name/{channel_name}':
     get:
       tags:
         - channels
@@ -683,7 +683,7 @@
             // GetChannelByName
             channel, resp := Client.GetChannelByName(<CHANNEL NAME>, <TEAMID>, "")
 
-  '/teams/name/{team_name}/channels/{channel_name}':
+  '/teams/name/{team_name}/channels/name/{channel_name}':
     get:
       tags:
         - channels


### PR DESCRIPTION
The ChannelByName (https://github.com/mattermost/platform/blob/master/api4/api.go#L40) and ChannelByNameAndTeamName (https://github.com/mattermost/platform/blob/master/api4/api.go#L41) API calls have the `name` as part of the path signature, it is currently missing from the documentation.