### PR TITLE
PLT-7025: Team Import API should return JSON, not attachment.

### DIFF
--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -849,9 +849,12 @@
           type: string
       responses:
         '200':
-          description: File attached with the results of the import
+          description: JSON object containing a base64 encoded text file of the import logs in its `results` property.
           schema:
-            type: file
+            type: object
+            properties:
+              results:
+                type: string
         '400':
           $ref: '#/responses/BadRequest'
         '403':


### PR DESCRIPTION
This helps fix PLT-7025 while also leaving the opportunity open to send back more structured data in future without breaking backwards compatibility.

@crspeller @jwilander what do you think of a) this returning JSON and b) the property name `results`?