### PR TITLE
PLT-6597: Add search matches to posts search results.

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -207,6 +207,26 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/Post'
 
+  PostListWithSearchMatches:
+    type: object
+    properties:
+      order:
+        type: array
+        items:
+            type: string
+        example: ["post_id1", "post_id12"]
+      posts:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Post'
+      matches:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+        example: {"post_id1": ["search match 1", "search match 2"]}
+
   TeamMap:
     type: object
     description: A mapping of teamIds to teams.

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -353,6 +353,8 @@
       summary: Search for team posts
       description: |
         Search posts in the team and from the provided terms string.
+        From server version 4.2 onwards, the returned value is a PostListWithSearchMatches. In 4.1 and earlier
+        the returned value is a PostList.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
       parameters:
@@ -381,7 +383,7 @@
         '200':
           description: Post list retrieval successful
           schema:
-            $ref: "#/definitions/PostList"
+            $ref: "#/definitions/PostListWithSearchMatches"
         '400':
           $ref: '#/responses/BadRequest'
         '401':


### PR DESCRIPTION
This adds the search matches to highlight to the data returned by the server.

For Elasicsearch, we need to return the "highlights" from the server like this, as it's impractical to reconstruct them client side when the system is quite complicated, and ES provides them anyway. For ordinary database search, I'm not sure whether it would make sense to also do this server side for a consistent API (I don't think it would be much work to move what we currently do to the server side in this case), or whether to leave it client side.