### PR TITLE
Fix emoji.yaml to run correctly

### DIFF
--- a/v4/source/emoji.yaml
+++ b/v4/source/emoji.yaml
@@ -9,14 +9,14 @@
         Must be authenticated.
       consumes: ["multipart/form-data"]
       parameters:
-        - name: files
+        - name: image
           in: formData
           description: A file to be uploaded
           required: true
           type: file
         - name: emoji
           in: formData
-          description: A JSON object containing a `name` field with the name of the emoji
+          description: A JSON object containing a `name` field with the name of the emoji and a `creator_id` field with the id of the authenticated user.
           required: true
           type: string
       responses:


### PR DESCRIPTION
I'm testing this API via cURL (Server version: v4.1).

I first sent:
```
$ curl -i -H 'Authorization: Bearer <TOKEN>' -F "files=@<IMAGE>.png;type=image/png" -F "emoji={\"name\":\"<NAME>\"}" https://mattermost.iggg.org/api/v4/emoji
```
The server respond `{"id":"model.emoji.user_id.app_error","message":"model.emoji.user_id.app_error","detailed_error":"","request_id":"<REQUEST_ID>","status_code":500}`.

If we add emoji correctly, we should be send:
```
curl -i -H 'Authorization: Bearer <TOKEN>' -F "image=@<IMAGE>;type=image/png" -F "emoji={\"creator_id\":\"<ID>\",\"name\":\"<NAME>\"}" https://mattermost.iggg.org/api/v4/emoji
```