### PR TITLE
PLT-7705: Add a data retention policy endpoint.

### DIFF
--- a/v4/source/dataretention.yaml
+++ b/v4/source/dataretention.yaml
@@ -6,6 +6,8 @@
       description: |
         Gets the current data retention policy details from the server, including what data should be purged and the cutoff times for each data type that should be purged.
         __Minimum server version__: 4.3
+        ##### Permissions
+        Requires an active session but no other permissions.
       responses:
         '200':
           description: Data retention policy details retrieved successfully.

--- a/v4/source/dataretention.yaml
+++ b/v4/source/dataretention.yaml
@@ -1,0 +1,17 @@
+  /data_retention/policy:
+    get:
+      tags:
+        - dataretention
+      summary: Get the data retention policy details.
+      description: |
+        Gets the current data retention policy details from the server, including what data should be purged and the cutoff times for each data type that should be purged.
+        __Minimum server version__: 4.3
+      responses:
+        '200':
+          description: Data retention policy details retrieved successfully.
+          schema:
+            $ref: '#/definitions/DataRetentionPolicy'
+        '500':
+          $ref: '#/responses/InternalServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -1430,6 +1430,22 @@ definitions:
         type: string
         description: A description of the token usage
 
+  DataRetentionPolicy:
+    type: object
+    properties:
+      message_deletion_enabled:
+        type: boolean
+        description: Indicates whether data retention policy deletion of messages is enabled.
+      file_deletion_enabled:
+        type: boolean
+        description: Indicates whether data retention policy deletion of file attachments is enabled.
+      message_retention_cutoff:
+        type: integer
+        description: The current server timestamp before which messages should be deleted.
+      file_retention_cutoff:
+        type: integer
+        description: The current server timestamp before which files should be deleted.
+
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'


### PR DESCRIPTION
This adds an API endpoint to get the data retention policy. The purpose is to enable the mobile apps to ask the API "What are the cutoff timestamps before which we should remove all messages/files we have cached?".

https://mattermost.atlassian.net/browse/PLT-7705