### PR TITLE
Fix posts search API endpoint

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -346,7 +346,7 @@
         '403':
           $ref: '#/responses/Forbidden'
 
-  '/team/{team_id}/posts/search':
+  '/teams/{team_id}/posts/search':
     post:
       tags:
         - posts


### PR DESCRIPTION
Plural form on "team" for endpoint `/teams/{team_id}/posts/search` was missing on documentation.