### PR TITLE
[PLT-7794] Added user access token enable/disable endpoints

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -1272,9 +1272,9 @@
     post:
       tags:
         - users
-      summary: Temporarily disable a user access token
+      summary: Disable personal access token
       description: |
-        Disable a user access token and delete any sessions using the token. The token can be re-enabled using `/users/tokens/enable`.
+        Disable a personal access token and delete any sessions using the token. The token can be re-enabled using `/users/tokens/enable`.
 
         __Minimum server version__: 4.4
 
@@ -1294,7 +1294,7 @@
                 type: string
       responses:
         '200':
-          description: User access token disable successful
+          description: Personal access token disable successful
           schema:
             $ref: '#/definitions/StatusOK'
         '400':
@@ -1308,9 +1308,9 @@
     post:
       tags:
         - users
-      summary: Enable a disabled user access token
+      summary: Enable personal access token
       description: |
-        Re-enable a user access token that has been disabled.
+        Re-enable a personal access token that has been disabled.
 
         __Minimum server version__: 4.4
 
@@ -1330,7 +1330,7 @@
                 type: string
       responses:
         '200':
-          description: User access token enable successful
+          description: Personal access token enable successful
           schema:
             $ref: '#/definitions/StatusOK'
         '400':

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -1268,3 +1268,74 @@
         '404':
           $ref: '#/responses/NotFound'
 
+  /users/tokens/disable:
+    post:
+      tags:
+        - users
+      summary: Temporarily disable a user access token
+      description: |
+        Disable a user access token and delete any sessions using the token. The token can be re-enabled using `/users/tokens/enable`.
+
+        __Minimum server version__: 4.4
+
+        ##### Permissions
+        Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      parameters:
+        - in: body
+          name: token
+          required: true
+          schema:
+            type: object
+            required:
+              - token
+            properties:
+              token:
+                description: The token to disable
+                type: string
+      responses:
+        '200':
+          description: User access token disable successful
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
+  /users/tokens/enable:
+    post:
+      tags:
+        - users
+      summary: Enable a disabled user access token
+      description: |
+        Re-enable a user access token that has been disabled.
+
+        __Minimum server version__: 4.4
+
+        ##### Permissions
+        Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      parameters:
+        - in: body
+          name: token
+          required: true
+          schema:
+            type: object
+            required:
+              - token
+            properties:
+              token:
+                description: The token to enable
+                type: string
+      responses:
+        '200':
+          description: User access token enable successful
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'


### PR DESCRIPTION
Adds documentation for the forthcoming server PR as part of https://github.com/mattermost/mattermost-server/issues/7583 and PLT-7794

A few points to note:
 * I wasn't sure what to put for the minimum server version, so feel free to provide input there
 * These endpoints currently rely on existing permissions rather than new ones
 * I created 2 endpoints rather than 1 unified "update token active status" endpoint because they do different things. Disabling a token also wipes out its related sessions. 