### PR TITLE
Fixed swagger-cli version to 1.0.0 and updated APIv4 POST /channels/{channel_id}/members

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-v3: .npminstall
 	@cat $(V3_SRC)/reactions.yaml >> $(V3_YAML)
 	@cat $(V3_SRC)/definitions.yaml >> $(V3_YAML)
 
-	@node_modules/swagger-cli/bin/swagger.js validate $(V3_YAML)
+	@node_modules/swagger-cli/bin/swagger-cli.js validate $(V3_YAML)
 
 	@echo Complete
 
@@ -52,14 +52,14 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/dataretention.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/definitions.yaml >> $(V4_YAML)
 
-	@node_modules/swagger-cli/bin/swagger.js validate $(V4_YAML)
+	@node_modules/swagger-cli/bin/swagger-cli.js validate $(V4_YAML)
 
 	@echo Complete
 
 .npminstall:
 	@echo Getting dependencies using npm
 
-	npm install swagger-cli
+	npm install swagger-cli@1.0.0
 	touch $@
 
 clean:

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -787,7 +787,16 @@
           name: body
           required: true
           schema:
-            $ref: '#/definitions/ChannelMember'
+            type: object
+            required:
+              - user_id
+            properties:
+              user_id:
+                type: string
+                description: The ID of user to add into the channel
+              post_root_id:
+                type: string
+                description: The ID of root post where link to add channel member originates
       responses:
         '201':
           description: Channel member creation successful
@@ -808,6 +817,9 @@
 
             // AddChannelMember
             cm, resp := Client.AddChannelMember(<CHANNEL ID>, <ID OF USER TO ADD>)
+
+            // AddChannelMemberWithRootId
+            cm, resp := Client.AddChannelMemberWithRootId(<CHANNEL ID>, <ID OF USER TO ADD>, <POST ROOT ID>)
 
   '/channels/{channel_id}/members/ids':
     post:


### PR DESCRIPTION
1) Fixed swagger-cli version to 1.0.0
2) Updated APIv4 POST /channels/{channel_id}/members
- [x] Related PR: https://github.com/mattermost/mattermost-server/pull/7730/files