### PR TITLE
[PLT-8173] updated documentation for creating incoming webhooks

### DIFF
--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -26,10 +26,10 @@
               description:
                 type: string
                 description: The description for this incoming webhook
-              post_username:
+              username:
                 type: string
                 description: The username this incoming webhook will post as.
-              post_icon_url:
+              icon_url:
                 type: string
                 description: The profile picture this incoming webhook will use when posting.
       responses:
@@ -148,10 +148,10 @@
               description:
                 type: string
                 description: The description for this incoming webhook
-              post_username:
+              username:
                 type: string
                 description: The username this incoming webhook will post as.
-              post_icon_url:
+              icon_url:
                 type: string
                 description: The profile picture this incoming webhook will use when posting.
       responses:

--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -26,6 +26,12 @@
               description:
                 type: string
                 description: The description for this incoming webhook
+              post_username:
+                type: string
+                description: The username this incoming webhook will post as.
+              post_icon_url:
+                type: string
+                description: The profile picture this incoming webhook will use when posting.
       responses:
         '201':
           description: Incoming webhook creation successful
@@ -142,6 +148,12 @@
               description:
                 type: string
                 description: The description for this incoming webhook
+              post_username:
+                type: string
+                description: The username this incoming webhook will post as.
+              post_icon_url:
+                type: string
+                description: The profile picture this incoming webhook will use when posting.
       responses:
         '200':
           description: Webhook update successful


### PR DESCRIPTION
This documentation complements the changes to support https://github.com/mattermost/mattermost-server/pull/8002, exposing a Username and Profile Picture configuration for incoming webhooks to override the defaults.

See https://github.com/mattermost/mattermost-server/issues/7880 for the original ticket.