### PR TITLE
[PLT-7793] Added /users/tokens/search to docs

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -1378,6 +1378,9 @@
       summary: Search tokens
       description: |
         Get a list of tokens based on search criteria provided in the request body. Searches are done against the token id, user id and username.
+        
+        __Minimum server version__: 4.7
+        
         ##### Permissions
         Must have `manage_system` permission.
       parameters:

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -1370,3 +1370,39 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+
+  /users/tokens/search:
+    post:
+      tags:
+        - users
+      summary: Search tokens
+      description: |
+        Get a list of tokens based on search criteria provided in the request body. Searches are done against the token id, user id and username.
+        ##### Permissions
+        Must have `manage_system` permission.
+      parameters:
+        - in: body
+          name: body
+          description: Search criteria
+          required: true
+          schema:
+            type: object
+            required:
+              - term
+            properties:
+              term:
+                description: The search term to match against the token id, user id or username.
+                type: string
+      responses:
+        '200':
+          description: Personal access token search successful
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/UserAccessTokenSanitized'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'


### PR DESCRIPTION
#### Summary

Adds a new endpoint `/users/tokens/search` to the documentation.

#### PR Links

- [Documentation PR](https://github.com/mattermost/mattermost-api-reference/pull/320)
- [Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/496)
- [Server PR](https://github.com/mattermost/mattermost-server/pull/8088)
- Redux PR

#### Ticket Link

- [Jira](https://mattermost.atlassian.net/browse/PLT-7793)
- [Github](https://github.com/mattermost/mattermost-server/issues/7584#issuecomment-352808489)

#### Checklist
- [x] Copy `.yaml` from existing route
- [x] Add `/users/tokens/search`
- [x] Update tags, summary, description, permissions, params, responses
- [x] Test with `make build-v4` and copy into Swagger  
  
  
  
  
  
  