### PR TITLE
[PLT-8494] Add delete_team to list of websocket events

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -225,6 +225,7 @@ tags:
       - new_user
       - leave_team
       - update_team
+      - delete_team
       - user_added
       - user_updated
       - user_role_updated


### PR DESCRIPTION
Add delete_team to list of websocket events

(Note: Only added this to APIv4.)