### PR TITLE
MM-8799: Basic Schemes API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/dataretention.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/plugins.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/roles.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/schemes.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/definitions.yaml >> $(V4_YAML)
 
 	@node_modules/swagger-cli/bin/swagger-cli.js validate $(V4_YAML)

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -1576,6 +1576,43 @@ definitions:
         type: boolean
         description: indicates if this role is managed by a scheme (true), or is a custom stand-alone role (false).
 
+  Scheme:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The unique identifier of the scheme.
+      name:
+        type: string
+        description: The human readable name for the scheme.
+      description:
+        type: string
+        description: A human readable description of the scheme.
+      create_at:
+        type: integer
+        description: The time at which the scheme was created.
+      update_at:
+        type: integer
+        description: The time at which the scheme was last updated.
+      delete_at:
+        type: integer
+        description: The time at which the scheme was deleted.
+      scope:
+        type: string
+        description: The scope to which this scheme can be applied, either "team" or "channel".
+      default_team_admin_role:
+        type: string
+        description: The id of the default team admin role for this scheme.
+      default_team_user_role:
+        type: string
+        description: The id of the default team user role for this scheme.
+      default_channel_admin_role:
+        type: string
+        description: The id of the default channel admin role for this scheme.
+      default_channel_user_role:
+        type: string
+        description: The id of the default channel user role for this scheme.
+
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -371,6 +371,8 @@ tags:
     description: Endpoints related to uploading and managing plugins.
   - name: roles
     description: Endpoints for creating, getting and updating roles.
+  - name: schemes
+    description: Endpoints for creating, getting and updating and deleting schemes.
 x-tagGroups:
   - name: Introduction
     tags:
@@ -410,6 +412,7 @@ x-tagGroups:
       - jobs
       - plugins
       - roles
+      - schemes
 schemes:
   - http
   - https

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -82,6 +82,8 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+        '501':
+          $ref: '#/responses/NotImplemented'
 
   '/schemes/{scheme_id}':
     get:
@@ -147,6 +149,8 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+        '501':
+          $ref: '#/responses/NotImplemented'
 
   '/schemes/{scheme_id}/patch':
     put:
@@ -192,6 +196,8 @@
           $ref: '#/responses/Forbidden'
         '404':
           $ref: '#/responses/NotFound'
+        '501':
+          $ref: '#/responses/NotImplemented'
 
   '/schemes/{scheme_id}/teams':
      get:

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -11,6 +11,11 @@
 
         __Minimum server version__: 4.10
       parameters:
+        - name: scope
+          in: query
+          description: Limit the results returned to the provided scope, either `team` or `channel`.
+          default: ""
+          type: string
         - name: page
           in: query
           description: The page to select.

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -1,4 +1,40 @@
   '/schemes':
+    get:
+      tags:
+        - schemes
+      summary: Get the schemes.
+      description: |
+        Get a page of schemes. Use the query parameters to modify the behaviour of this endpoint.
+
+        ##### Permissions
+        Must have `manage_system` permission.
+
+        __Minimum server version__: 4.10
+      parameters:
+        - name: page
+          in: query
+          description: The page to select.
+          default: "0"
+          type: string
+        - name: per_page
+          in: query
+          description: The number of schemes per page.
+          default: "60"
+          type: string
+      responses:
+        '200':
+          description: Scheme list retrieval successful
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Scheme'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
     post:
       tags:
         - schemes
@@ -9,7 +45,7 @@
         ##### Permissions
         Must have `manage_system` permission.
 
-        __Minimum server version__: 4.9
+        __Minimum server version__: 4.10
       parameters:
         - in: body
           name: scheme
@@ -53,7 +89,7 @@
         ##### Permissions
         Requires an active session but no other permissions.
 
-        __Minimum server version__: 4.9
+        __Minimum server version__: 4.10
       parameters:
         - name: scheme_id
           in: path
@@ -88,7 +124,7 @@
         ##### Permissions
         Must have `manage_system` permission.
 
-        __Minimum server version__: 4.9
+        __Minimum server version__: 4.10
       parameters:
         - name: scheme_id
           in: path
@@ -118,7 +154,7 @@
         ##### Permissions
         `manage_system` permission is required.
 
-        __Minimum server version__: 4.9
+        __Minimum server version__: 4.10
       parameters:
         - name: scheme_id
           in: path

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -1,0 +1,154 @@
+  '/schemes':
+    post:
+      tags:
+        - schemes
+      summary: Create a scheme
+      description: |
+        Create a new scheme.
+
+        ##### Permissions
+        Must have `manage_system` permission.
+
+        __Minimum server version__: 4.9
+      parameters:
+        - in: body
+          name: scheme
+          description: Scheme object to create
+          required: true
+          schema:
+            type: object
+            required:
+              - name
+              - scope
+            properties:
+              name:
+                type: string
+                description: The name of the scheme
+              description:
+                type: string
+                description: The description of the scheme
+              scope:
+                type: string
+                description: The scope of the scheme ("team" or "channel")
+      responses:
+        '201':
+          description: Scheme creation successful
+          schema:
+            $ref: '#/definitions/Scheme'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
+  '/schemes/{scheme_id}':
+    get:
+      tags:
+        - schemes
+      summary: Get a scheme
+      description: |
+        Get a scheme from the provided scheme id.
+
+        ##### Permissions
+        Requires an active session but no other permissions.
+
+        __Minimum server version__: 4.9
+      parameters:
+        - name: scheme_id
+          in: path
+          description: Scheme GUID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Scheme retrieval successful
+          schema:
+            $ref: '#/definitions/Scheme'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '404':
+          $ref: '#/responses/NotFound'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            scheme, resp := Client.GetScheme(<SCHEMEID>, "")
+
+    delete:
+      tags:
+        - schemes
+      summary: Delete a scheme
+      description: |
+        Soft deletes a scheme, by marking the scheme as deleted in the database.
+
+        ##### Permissions
+        Must have `manage_system` permission.
+
+        __Minimum server version__: 4.9
+      parameters:
+        - name: scheme_id
+          in: path
+          description: ID of the scheme to delete
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Scheme deletion successful
+          schema:
+            $ref: "#/definitions/StatusOK"
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
+  '/schemes/{scheme_id}/patch':
+    put:
+      tags:
+        - schemes
+      summary: Patch a scheme
+      description: |
+        Partially update a scheme by providing only the fields you want to update. Omitted fields will not be updated. The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+
+        ##### Permissions
+        `manage_system` permission is required.
+
+        __Minimum server version__: 4.9
+      parameters:
+        - name: scheme_id
+          in: path
+          description: Scheme GUID
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Scheme object to be updated
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The human readable name of the scheme
+              description:
+                type: string
+                description: The description of the scheme
+      responses:
+        '200':
+          description: Scheme patch successful
+          schema:
+            $ref: '#/definitions/Scheme'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -188,3 +188,92 @@
         '404':
           $ref: '#/responses/NotFound'
 
+  '/schemes/{scheme_id}/teams':
+     get:
+       tags:
+         - schemes
+       summary: Get a page of teams which use this scheme.
+       description: |
+         Get a page of teams which use this scheme. The provided Scheme ID should be for a Team-scoped Scheme.
+         Use the query parameters to modify the behaviour of this endpoint.
+
+         ##### Permissions
+         `manage_system` permission is required.
+
+         __Minimum server version__: 4.10
+       parameters:
+         - name: scheme_id
+           in: path
+           description: Scheme GUID
+           required: true
+           type: string
+         - name: page
+           in: query
+           description: The page to select.
+           default: "0"
+           type: string
+         - name: per_page
+           in: query
+           description: The number of teams per page.
+           default: "60"
+           type: string
+       responses:
+         '200':
+           description: Team list retrieval successful
+           schema:
+             type: array
+             items:
+               $ref: '#/definitions/Team'
+         '400':
+           $ref: '#/responses/BadRequest'
+         '401':
+           $ref: '#/responses/Unauthorized'
+         '403':
+           $ref: '#/responses/Forbidden'
+         '404':
+           $ref: '#/responses/NotFound'
+
+  '/schemes/{scheme_id}/channels':
+      get:
+        tags:
+          - schemes
+        summary: Get a page of channels which use this scheme.
+        description: |
+          Get a page of channels which use this scheme. The provided Scheme ID should be for a Channel-scoped Scheme.
+          Use the query parameters to modify the behaviour of this endpoint.
+
+          ##### Permissions
+          `manage_system` permission is required.
+
+          __Minimum server version__: 4.10
+        parameters:
+          - name: scheme_id
+            in: path
+            description: Scheme GUID
+            required: true
+            type: string
+          - name: page
+            in: query
+            description: The page to select.
+            default: "0"
+            type: string
+          - name: per_page
+            in: query
+            description: The number of channels per page.
+            default: "60"
+            type: string
+        responses:
+          '200':
+            description: Channel list retrieval successful
+            schema:
+              type: array
+              items:
+                $ref: '#/definitions/Channel'
+          '400':
+            $ref: '#/responses/BadRequest'
+          '401':
+            $ref: '#/responses/Unauthorized'
+          '403':
+            $ref: '#/responses/Forbidden'
+          '404':
+            $ref: '#/responses/NotFound'


### PR DESCRIPTION
This provides the basic API for CRUD of Schemes, to enable the management of them through the System Console. It forms the core of Phase 2 advanced permissions.

There will be some additional standalone API changes in subsequent PRs for setting the Scheme on Team or Channel objects.

**Ignore the build error - Jenkins is broken.**