### PR TITLE
[MM-9798] API v4 Documentation for Status/Get User Status does not match payload received

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -1351,8 +1351,6 @@ definitions:
         type: boolean
       last_activity_at:
         type: integer
-      active_channel:
-        type: string
 
   OAuthApp:
     type: object


### PR DESCRIPTION
the field ActiveChannel is used only on the server side, and not goes to
the API response, so removing this field from the docs

Signed-off-by: cpanato <ctadeu@gmail.com>



JIRA: https://mattermost.atlassian.net/browse/MM-9798