### PR TITLE
Remove invalid required paramter from oauth app PUT.

### DIFF
--- a/v4/source/oauth.yaml
+++ b/v4/source/oauth.yaml
@@ -143,7 +143,6 @@
             required:
               - id
               - name
-              - display_name
               - description
               - callback_urls
               - homepage


### PR DESCRIPTION
Fixes the build of master.

Jenkins is still confused though, so thinks this PR doesn't build (it does, and it fixes the error).