### PR TITLE
MM-9730: API to manage the scheme props of team members.

### DIFF
--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -813,7 +813,7 @@
     put:
       tags:
         - teams
-      summary: Update the `scheme_admin` / `scheme_user` properties of a team member.
+      summary: Update the scheme-derived roles of a team member.
       description: |
         Update a team member's scheme_admin/scheme_user properties. Typically this should either be `scheme_admin=false, scheme_user=true` for ordinary team member, or `scheme_admin=true, scheme_user=true` for a team admin.
 
@@ -848,7 +848,7 @@
                 type: boolean
       responses:
         '200':
-          description: Team member promoted to a Scheme Admin.
+          description: Team member's scheme-derived roles updated successfully.
           schema:
             $ref: '#/definitions/StatusOK'
         '400':

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -809,6 +809,57 @@
         '404':
           $ref: '#/responses/NotFound'
 
+  '/teams/{team_id}/members/{user_id}/schemeRoles':
+    put:
+      tags:
+        - teams
+      summary: Update the `scheme_admin` / `scheme_user` properties of a team member.
+      description: |
+        Update a team member's scheme_admin/scheme_user properties. Typically this should either be `scheme_admin=false, scheme_user=true` for ordinary team member, or `scheme_admin=true, scheme_user=true` for a team admin.
+
+        __Minimum server version__: 4.10
+
+        ##### Permissions
+        Must be authenticated and have the `manage_team_roles` permission.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team GUID
+          required: true
+          type: string
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Scheme properties.
+          required: true
+          schema:
+            type: object
+            required:
+              - scheme_admin
+              - scheme_user
+            properties:
+              scheme_admin:
+                type: boolean
+              scheme_user:
+                type: boolean
+      responses:
+        '200':
+          description: Team member promoted to a Scheme Admin.
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+
   '/users/{user_id}/teams/unread':
     get:
       tags:

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -817,7 +817,7 @@
       description: |
         Update a team member's scheme_admin/scheme_user properties. Typically this should either be `scheme_admin=false, scheme_user=true` for ordinary team member, or `scheme_admin=true, scheme_user=true` for a team admin.
 
-        __Minimum server version__: 4.10
+        __Minimum server version__: 5.0
 
         ##### Permissions
         Must be authenticated and have the `manage_team_roles` permission.


### PR DESCRIPTION
Adds an API endpoint to manage the `scheme_admin`/`scheme_user` properties of `TeamMember` objects, as part of Advanced Permissions Phase 2.

An analogous API will be added for `ChannelMember` objects once the design of this one has been agreed.

https://mattermost.atlassian.net/browse/MM-9730

**Ignore the build failure - it's on `master` and waiting for Jenkins to be fixed before the PR fixing it can be merged**