### PR TITLE
Clarify what deleting a channel or team do

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -296,7 +296,7 @@
         - channels
       summary: Delete a channel
       description: |
-        Delete a channel based from provided channel id string.
+        Soft deletes a channel, by marking the channel as deleted in the database. Soft deleted channels will not be accessible in the user interface.
         ##### Permissions
         `delete_public_channel` permission if the channel is public,
         `delete_private_channel` permission if the channel is private,

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -159,7 +159,9 @@
         - teams
       summary: Delete a team
       description: |
-        Delete a team softly and put in archived only.
+        Soft deletes a team, by marking the team as deleted in the database. Soft deleted teams will not be accessible in the user interface.
+        
+        Optionally use the permanent query parameter to hard delete the team for compliance reasons.
         ##### Permissions
         Must have the `manage_team` permission.
       parameters:


### PR DESCRIPTION
Clarify what deleting a channel or team do (soft delete instead of a hard delete)

Ticket to disable the permanent query parameter from `DELETE /teams/{team_id}` by default https://mattermost.atlassian.net/browse/MM-9916