### PR TITLE
MM-9990: Ephemeral Post Documentation

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -47,6 +47,47 @@
         '403':
           $ref: '#/responses/Forbidden'
 
+  /posts/ephemeral:
+    post:
+      tags:
+        - posts
+      summary: Create a ephemeral post
+      description: |
+        Create a new ephemeral post in a channel.
+        ##### Permissions
+        Must have `create_post_ephemeral` permission (currently only given to system adin)
+      parameters:
+        - in: body
+          name: ephemeral_post
+          description: Ephemeral Post object to send
+          required: true
+          schema:
+            type: object
+            required:
+              - user_id
+              - post
+            properties:
+              user_id:
+                type: string
+                description: The target user id for the ephemeral post
+              post:
+                type: object
+                required:
+                  - channel_id
+                  - message
+                description: Post object to create
+      responses:
+        '201':
+          description: Post creation successful
+          schema:
+            $ref: '#/definitions/Post'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
   '/posts/{post_id}':
     get:
       tags:
@@ -223,7 +264,7 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
-  
+
   '/users/{user_id}/posts/flagged':
     get:
       tags:


### PR DESCRIPTION
This implements the documentation for change MM-9990 from https://github.com/mattermost/mattermost-server/pull/8611. Since the request body expects a structure that didn't exist as a schema I was a bit uncertain how to implement it, so if you'd prefer to create a dedicated schema for it or another proposal I am more than happy to change it.