### PR TITLE
[MM-10354] Add APIv4 to remove team icon

### DIFF
--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -741,6 +741,39 @@
         '501':
           $ref: '#/responses/NotImplemented'
 
+    delete:
+      tags:
+        - teams
+      summary: Remove the team icon
+      description: |
+        Remove the team icon for the team.
+
+        __Minimum server version__: 4.10
+
+        ##### Permissions
+        Must be authenticated and have the `manage_team` permission.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team GUID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Team icon successfully remove
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '500':
+          $ref: '#/responses/InternalServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'
+
   '/teams/{team_id}/members/{user_id}/roles':
     put:
       tags:


### PR DESCRIPTION
Add APIv4 to remove team icon
- `DELETE '/teams/{team_id}/image`

Server PR (merged) - https://github.com/mattermost/mattermost-server/pull/8684

Note: `make build` passed locally