### PR TITLE
Fix invitation token id query parameter name

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -8,9 +8,14 @@
         ##### Permissions
         No permission required but user creation can be controlled by server configuration.
       parameters:
+        - name: t
+          in: query
+          description: Token id from an email invitation
+          required: false
+          type: string
         - name: iid
           in: query
-          description: Invitation token id
+          description: Token id from an invitation link
           required: false
           type: string
         - in: body

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -8,7 +8,7 @@
         ##### Permissions
         No permission required but user creation can be controlled by server configuration.
       parameters:
-        - name: t
+        - name: iid
           in: query
           description: Invitation token id
           required: false


### PR DESCRIPTION
To create a user via the API (https://api.mattermost.com/#tag/users%2Fpaths%2F~1users%2Fpost) a query parameter named `t` can be passed to specify an invitation token id.
When doing so, an HTTP 403 error code is returned as the Mattermost app configuration parameter `EnableOpenServer` is set to `false`. 

According to the call made by the Mattermost web interface to the API when creating an account via an invitation link, the query parameter's name for the invitation token id is `iid` (with a double i) instead of `t`.