### PR TITLE
Remove extra_update_at from Channels call

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -133,7 +133,7 @@ definitions:
       total_msg_count:
         type: integer
       extra_update_at:
-        description: Removed in Mattermost 5.0 release
+        description: Deprecated in Mattermost 5.0 release
         type: integer
         format: int64
       creator_id:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -132,9 +132,6 @@ definitions:
         type: integer
       total_msg_count:
         type: integer
-      extra_update_at:
-        type: integer
-        format: int64
       creator_id:
         type: string
 

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -132,6 +132,10 @@ definitions:
         type: integer
       total_msg_count:
         type: integer
+      extra_update_at:
+        description: Removed in Mattermost 5.0 release
+        type: integer
+        format: int64
       creator_id:
         type: string
 


### PR DESCRIPTION
This is for v5.0: https://github.com/mattermost/mattermost-server/pull/8762

I know the database column was deprecated but not removed..so if we should still keep this in the API doc, feel free to close this PR.