### PR TITLE
[MM-10471] Change permission from "manage_team" to "convert_public_channel" in converting public to private channel

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -407,7 +407,7 @@
           __Minimum server version__: 4.10
 
           ##### Permissions
-          `manage_team` permission for the team of the channel.
+          `convert_public_channel` permission for the team of the channel.
         parameters:
           - name: channel_id
             in: path


### PR DESCRIPTION
`POST '/channels/{channel_id}/convert'`

Change permission from "manage_team" to "convert_public_channel" in converting public to private channel.

Server PR - https://github.com/mattermost/mattermost-server/pull/8832