### PR TITLE
MM-6992 Added "matches" field to post search results

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -255,7 +255,7 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/Post'
       matches:
-        description: A mapping of post IDs to a list of matched terms within the post. This field will only be populated on servers running version 5.0 or greater with Elasticsearch enabled.
+        description: A mapping of post IDs to a list of matched terms within the post. This field will only be populated on servers running version 5.1 or greater with Elasticsearch enabled.
         type: object
         additionalProperties:
           type: array

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -242,6 +242,27 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/Post'
 
+  PostListWithSearchMatches:
+    type: object
+    properties:
+      order:
+        type: array
+        items:
+            type: string
+        example: ["post_id1", "post_id12"]
+      posts:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Post'
+      matches:
+        description: A mapping of post IDs to a list of matched terms within the post. This field will only be populated on servers running version 5.0 or greater with Elasticsearch enabled.
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+        example: {"post_id1": ["search match 1", "search match 2"]}
+
   TeamMap:
     type: object
     description: A mapping of teamIds to teams.

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -432,7 +432,7 @@
         '200':
           description: Post list retrieval successful
           schema:
-            $ref: "#/definitions/PostList"
+            $ref: "#/definitions/PostListWithSearchMatches"
         '400':
           $ref: '#/responses/BadRequest'
         '401':


### PR DESCRIPTION
To support server-side search highlighting, the server will return a list of matches along with search results like
```
// Searching for appl*
{
    "posts": ...,
    "order": ...,
    "results": {
        "postid1": ["apple", "apples"],
        "postid2": ["apply"],
    }
}
```
as long as the server is the required version and has Elasticsearch enabled. Eventually, we could have the server return the matched terms for all versions, but I don't think it's worth the effort to move that logic to the server for database searches at this time.