### PR TITLE
MM-10928: fix /system/ping docs

### DIFF
--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -12,9 +12,7 @@
         '200':
           description: Status of the system
           schema:
-            type: object
-            items:
-              type: string
+            $ref: "#/definitions/StatusOK"
         '500':
           $ref: '#/responses/InternalServerError'
           schema:


### PR DESCRIPTION
This references the /definitions/StatusOK ref to get the usual:
```
    {
      "status": "string"
    }
```

Note that the actual API currently returns additional fields referencing
the `ClientRequirements` struct from the configuration, but this
scheduled to be moved to a different endpoint and we're not encouraging
use of same.