### PR TITLE
Remove note about APIv4 vs APIv3

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -1,8 +1,6 @@
 swagger: '2.0'
 info:
   description: |
-    ### API v4 is stable with the Mattermost server 4.0 release. API v3 was deprecated on January 16th, 2018, and scheduled for removal in Mattermost v5.0. [Details here](/#tag/APIv3-Deprecation). Looking for the API v3 reference? It has moved [here](https://api.mattermost.com/v3).
-
     There is also a work-in-progress [Postman API reference](https://documenter.getpostman.com/view/4508214/RW8FERUn).
 
   version: 4.0.0


### PR DESCRIPTION
APIv3 deprecation has its own section in the sidebar