### PR TITLE
[MM-11210] Add docs for GET '/users/{user_id}/channels/{channel_id}/posts/unread'

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -397,6 +397,33 @@
         '403':
           $ref: '#/responses/Forbidden'
 
+  '/channels/{channel_id}/posts/unread':
+    get:
+      tags:
+        - posts
+      summary: Get posts for a channel around last unread
+      description: |
+        Get posts in a channel around last unread post of a member.
+        ##### Permissions
+        Must have `read_channel` permission for the channel.
+      parameters:
+        - name: channel_id
+          in: path
+          description: The channel ID to get the posts for
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Post list retrieval successful
+          schema:
+            $ref: "#/definitions/PostList"
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+
   '/teams/{team_id}/posts/search':
     post:
       tags:

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -397,20 +397,36 @@
         '403':
           $ref: '#/responses/Forbidden'
 
-  '/channels/{channel_id}/posts/unread':
+  '/users/{user_id}/channels/{channel_id}/posts/unread':
     get:
       tags:
         - posts
       summary: Get posts for a channel around last unread
       description: |
         Get posts in a channel around last unread post of a member.
+        __Minimum server version: 5.3__
         ##### Permissions
         Must have `read_channel` permission for the channel.
       parameters:
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          type: string
         - name: channel_id
           in: path
-          description: The channel ID to get the posts for
+          description: Channel GUID
           required: true
+          type: string
+        - name: limit_before
+          in: query
+          description: The number of posts before the last unread post
+          default: "60"
+          type: string
+        - name: limit_after
+          in: query
+          description: The number of posts after and including the last unread post
+          default: "60"
           type: string
       responses:
         '200':


### PR DESCRIPTION
Add docs for `GET '/users/{user_id}/channels/{channel_id}/posts/unread'`

Server PR https://github.com/mattermost/mattermost-server/pull/9108 is merged into `scrolling-overhaul` branch.

This is for dev review, but should not be merged until the `scrolling-overhaul` branch is merged into master.

Update:  Follow up PR - https://github.com/mattermost/mattermost-server/pull/9229