### PR TITLE
[MM-11593] Add a note to channel member delete endpoint

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -999,7 +999,7 @@
       description: |
         Delete a channel member, effectively removing them from a channel.
 
-        Since server version 5.3, channel member can only be deleted either from public or private channel.
+        In Mattermost Server v5.3 and later, channel members can only be deleted from public or private channels.
         ##### Permissions
         `manage_public_channel_members` permission if the channel is public.
         `manage_private_channel_members` permission if the channel is private.

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -998,6 +998,8 @@
       summary: Remove user from channel
       description: |
         Delete a channel member, effectively removing them from a channel.
+
+        Since server version 5.3, channel member can only be deleted either from public or private channel.
         ##### Permissions
         `manage_public_channel_members` permission if the channel is public.
         `manage_private_channel_members` permission if the channel is private.

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -999,7 +999,7 @@
       description: |
         Delete a channel member, effectively removing them from a channel.
 
-        In Mattermost Server v5.3 and later, channel members can only be deleted from public or private channels.
+        In server version 5.3 and later, channel members can only be deleted from public or private channels.
         ##### Permissions
         `manage_public_channel_members` permission if the channel is public.
         `manage_private_channel_members` permission if the channel is private.


### PR DESCRIPTION
Add a note to channel member delete endpoint, like:
> Since server version 5.3, channel member can only be deleted either from public or private channel.

Jira ticket: [MM-11593](https://mattermost.atlassian.net/browse/MM-11593)