### PR TITLE
Add documentation for 'include_deleted' pt2

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -783,6 +783,12 @@
           description: Channel Name
           required: true
           type: string
+        - name: include_deleted
+          in: query
+          description: Defines if deleted channels should be returned or not
+          type: string
+          enum: [true, false]
+          default: "false"
       responses:
         '200':
           description: Channel retrieval successful


### PR DESCRIPTION
The `/teams/name/{team_name}/channels/name/{channel_name}` has a `include_deleted` query parameter that allows to return deleted channels too

See: https://github.com/mattermost/mattermost-api-reference/pull/398#issuecomment-426575950