### PR TITLE
Fix charset bug on Firefox browser

### DIFF
--- a/v4/html/index.html
+++ b/v4/html/index.html
@@ -4,6 +4,7 @@
     <title>Mattermost API Reference</title>
     <!-- needed for adaptive design -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
 
     <link rel="shortcut icon" href="./static/favicon.ico">
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9696352/47255843-94781e00-d4b1-11e8-9a26-327a1bdf176f.png)

`<meta charset='utf-8'>` is required for firefox with non-US locale

```
LC_ALL="en_US.UTF-8" firefox index.html # works
LC_ALL="ko_KR.UTF-8" firefox index.html # not works
```

