### PR TITLE
Add post id to body of update API

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -169,6 +169,10 @@
           schema:
             type: object
             properties:
+              id:
+                description: ID of the post to update
+                required: true
+                type: string
               is_pinned:
                 description: Set to `true` to pin the post to the channel it is in
                 type: boolean

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -168,6 +168,8 @@
           required: true
           schema:
             type: object
+            required:
+              - id
             properties:
               id:
                 description: ID of the post to update

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -173,7 +173,6 @@
             properties:
               id:
                 description: ID of the post to update
-                required: true
                 type: string
               is_pinned:
                 description: Set to `true` to pin the post to the channel it is in


### PR DESCRIPTION
I am using the Japanese version of Mattermost. 
System version is 5.4.0.

An error occurred when using the API for updating post.
↓ error body.
```
{
  "id": "api.context.invalid_body_param.app_error",
  "message": "リクエストボディのpost_idが存在しないか不正です",
  "detailed_error": "",
  "request_id": "xi3m99tt63rfxe3mipz48zzw6r",
  "status_code": 400
}
```

With this fix, the id parameter has been added.
This may not be reflected in the manual.
https://github.com/mattermost/mattermost-server/commit/fdbb6de3d52a5f41f075812e3b87616685a21b9b#diff-2f7d4446bf6cc464490bf4dd04b6d97bR386