### PR TITLE
GH-6798 added the doc for the bulk reactions endpoint

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2296,6 +2296,12 @@ definitions:
         type: integer
         format: int64
 
+  PostIdToReactionsMap:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        $ref: '#/definitions/Reaction'
 
 externalDocs:
   description: Find out more about Mattermost

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -99,6 +99,8 @@
         Get a list of reactions made by all users to a given post.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
+
+        __Minimum server version__: 5.8
       parameters:
         - in: body
           name: postIds

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -89,3 +89,33 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+
+  '/posts/ids/reactions':
+    post:
+      tags:
+        - reactions
+      summary: Bulk get the reaction for posts
+      description: |
+        Get a list of reactions made by all users to a given post.
+        ##### Permissions
+        Must have `read_channel` permission for the channel the post is in.
+      parameters:
+        - in: body
+          name: postIds
+          description: Array of post IDs
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Reactions retrieval successful
+          schema:
+            $ref: "#/definitions/PostIdToReactionsMap"
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'


### PR DESCRIPTION
Added the api doc for the new endpoint for bulk selecting reactions to posts.
Ticket - https://github.com/mattermost/mattermost-server/issues/6798