### PR TITLE
Fix a typo and broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 ## Contributing
 
-We're accepting pull requests! Specifically we're looking for documenation on routes defined [here](https://github.com/mattermost/mattermost-server/tree/master/api).
+We're accepting pull requests! Specifically we're looking for documenation on routes defined [here](https://github.com/mattermost/mattermost-server/tree/master/api4).
 
-All the documentation is written in YAML and found in the [source](https://github.com/mattermost/mattermost-api-reference/tree/master/source) directory.
+All the documentation is written in YAML and found in the [source](https://github.com/mattermost/mattermost-api-reference/tree/master/v4/source) directory.
 
-* When adding a new route, please add it to the correct file. For example, a channel route will go in [channels.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/source/channels.yaml).
-* To add a new tag, please do so in [introduction.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/source/introduction.yaml)
-* Definitions should be added to [definitions.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/source/definitions.yaml)
+* When adding a new route, please add it to the correct file. For example, a channel route will go in [channels.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/channels.yaml).
+* To add a new tag, please do so in [introduction.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/introduction.yaml)
+* Definitions should be added to [definitions.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/definitions.yaml)
 
 There is no strict style guide but please try to follow the example of the existing documentation.
 

--- a/v4/source/roles.yaml
+++ b/v4/source/roles.yaml
@@ -157,4 +157,4 @@
 
               roleNames := []string{<NAME OF ROLE1>, <NAME OF ROLE2>, ...}
 
-              roles, resp := Client.GetRolesByName(roleNames)
+              roles, resp := Client.GetRolesByNames(roleNames)


### PR DESCRIPTION
Fix a typo in the go example of `roles/name` and update some old links.