### PR TITLE
Documentation update

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -379,7 +379,7 @@
         - users
       summary: Update a user
       description: |
-        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored. Please note props are not reuired, but will be set to default values if not included.
+        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored. Please note props are not required, but will be set to default values if not included.
         ##### Permissions
         Must be logged in as the user being updated or have the `edit_other_users` permission.
       parameters:

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -379,7 +379,7 @@
         - users
       summary: Update a user
       description: |
-        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored. Please note props are not reuired, but will be set to default values if not included.
         ##### Permissions
         Must be logged in as the user being updated or have the `edit_other_users` permission.
       parameters:

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -379,7 +379,7 @@
         - users
       summary: Update a user
       description: |
-        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored. Please note props are not required, but will be set to default values if not included.
+        Update a user by providing the user object. The fields that can be updated are defined in the request body, all other provided fields will be ignored. Any fields not included in the request body will be set to null or reverted to default values. 
         ##### Permissions
         Must be logged in as the user being updated or have the `edit_other_users` permission.
       parameters:


### PR DESCRIPTION
A critical provisioning integration was using the PUT endpoint, expecting it to work like a patch. We thought that this may make the docs a little more clear.