### PR TITLE
Update posts.yaml

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -34,7 +34,7 @@
                   type: string
               props:
                 description: A general JSON property bag to attach to the post
-                type: JSON object
+                type: object
       responses:
         '201':
           description: Post creation successful

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -34,7 +34,7 @@
                   type: string
               props:
                 description: A general JSON property bag to attach to the post
-                type: array
+                type: JSON object
       responses:
         '201':
           description: Post creation successful

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -34,7 +34,7 @@
                   type: string
               props:
                 description: A general JSON property bag to attach to the post
-                type: string
+                type: array
       responses:
         '201':
           description: Post creation successful


### PR DESCRIPTION
It was reported that the props field for create post API is aa JSON object, not a string. If it's indeed a JSON object, wondering if this is incorrect elsewhere in the API docs