### PR TITLE
[MM-13810] Adds user_id and team id required body parameters to the update endpoints

### DIFF
--- a/v4/source/status.yaml
+++ b/v4/source/status.yaml
@@ -45,7 +45,11 @@
             type: object
             required:
               - status
+              - user_id
             properties:
+              user_id:
+                type: string
+                description: User ID
               status:
                 type: string
                 description: User status, can be `online`, `away`, `offline` and `dnd`

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -121,6 +121,7 @@
           schema:
             type: object
             required:
+              - id
               - display_name
               - description
               - company_name
@@ -128,6 +129,8 @@
               - invite_id
               - allow_open_invite
             properties:
+              id:
+                type: string
               display_name:
                 type: string
               description:


### PR DESCRIPTION
### Summary
This PR adds the `user_id` body parameter and the `id` body parameter to the correspondant update endpoints. The rationale behind adding the parameters to the docs instead removing the need for them is consistency. Requiring the entity id in both the URL path and the request body is used in several places through the API, including the update endpoints for post, user and team.

[Related server PR](https://github.com/mattermost/mattermost-server/pull/10361)

### Ticket link
[MM-13810](https://mattermost.atlassian.net/browse/MM-13810)