### PR TITLE
Remove deprecated LogSettings.FileFormat from config definition

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -1092,8 +1092,6 @@ definitions:
             type: boolean
           FileLevel:
             type: string
-          FileFormat:
-            type: string
           FileLocation:
             type: string
           EnableWebhookDebugging:
@@ -1566,8 +1564,6 @@ definitions:
           EnableFile:
             type: boolean
           FileLevel:
-            type: boolean
-          FileFormat:
             type: boolean
           FileLocation:
             type: boolean


### PR DESCRIPTION
This setting was deprecated back in 4.10