### PR TITLE
[MM-14751] Add group_constrained to the user list and search endpoints

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -114,6 +114,10 @@
           in: query
           description: The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
           type: string
+        - name: group_constrained
+          in: query
+          description: When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
+          type: boolean
         - name: without_team
           in: query
           description: Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
@@ -256,6 +260,9 @@
               not_in_channel_id:
                 description: If provided, only search users not in this channel. Must specifiy `team_id` when using this option
                 type: string
+              group_constrained:
+                description: When used with `not_in_channel_id` or `not_in_team_id`, returns only the users that are allowed to join the channel or team based on its group constrains.
+                type: boolean
               allow_inactive:
                 description: When `true`, include deactivated users in the results
                 type: boolean


### PR DESCRIPTION
#### Summary
Adds the parameter `group_constrained` to the `/users` and `/users/search` endpoints.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14751

#### Related Pull Requests
- [Has server changes](https://github.com/mattermost/mattermost-server/pull/10678)
- [Has webapp changes](https://github.com/mattermost/mattermost-webapp/pull/2692)
- [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/817)
- [Has mobile changes](https://github.com/mattermost/mattermost-mobile/pull/2737)