### PR TITLE
[MM-13671] Add Regenerate Team InviteID Method

### DIFF
--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -901,6 +901,46 @@
 
             stats, resp := Client.GetTeamStats(teamID, "")
 
+  '/teams/{team_id}/regenerate_invite_id':
+    post:
+      tags:
+        - teams
+      summary: Regenerate the Invite ID from a Team
+      description: |
+        Regenerates the invite ID used in invite links of a team
+        ##### Permissions
+        Must be authenticated and have the `manage_team` permission.
+      parameters:
+        - name: team_id
+          in: path
+          description: Team GUID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Team Invite ID regenerated
+          schema:
+            $ref: '#/definitions/Team'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/platform/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+            team, resp := Client.RegenerateTeamInviteId(teamID)
+
   '/teams/{team_id}/image':
     get:
       tags:


### PR DESCRIPTION
This adds the documentation for the new endpoint introduced in https://github.com/mattermost/mattermost-server/pull/10536