### PR TITLE
Update Direct-channel API definition

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -79,6 +79,8 @@
             type: array
             items:
               type: string
+            minItems: 2
+            maxItems: 2
       responses:
         '201':
           description: Direct channel creation successful


### PR DESCRIPTION
The direct-channel creation requires exactly 2 user ids as parameters.
Swagger allows arrays to define the min/max number of items