### PR TITLE
Add missing parameters section to Get Open Graph Metadata API

### DIFF
--- a/v4/source/opengraph.yaml
+++ b/v4/source/opengraph.yaml
@@ -10,6 +10,18 @@
 
         ##### Permissions
         No permission required but must be logged in.
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - url
+            properties:
+              url:
+                type: string
+                description: The URL to get Open Graph Metadata.
       responses:
         '200':
           description: Open Graph retrieval successful


### PR DESCRIPTION
`url` parameter required but it is not documented.