### PR TITLE
MM-15452 - Add docs for /bots/{bot_user_id}/icon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-v4: .npminstall
 run:
 	@echo Starting redoc server
 
-	@node_modules/redoc-cli/index.js serve v4/html/static/mattermost-openapi-v4.yaml
+	npx redoc-cli serve v4/html/static/mattermost-openapi-v4.yaml
 
 clean:
 	@echo Cleaning

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-v4: .npminstall
 run:
 	@echo Starting redoc server
 
-	redoc-cli serve v4/html/static/mattermost-openapi-v4.yaml
+	@node_modules/redoc-cli/index.js serve v4/html/static/mattermost-openapi-v4.yaml
 
 clean:
 	@echo Cleaning

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,13 @@ build-v4: .npminstall
 	@echo Getting dependencies using npm
 
 	npm install swagger-cli@1.0.0
+	npm install redoc-cli
 	touch $@
+
+run:
+	@echo Starting redoc server
+
+	redoc-cli serve v4/html/static/mattermost-openapi-v4.yaml
 
 clean:
 	@echo Cleaning

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is no strict style guide but please try to follow the example of the exist
 
 To build the full YAML, run `make build` and it will be output to `html/static/mattermost-openapi.yaml`. This will also check syntax using [swagger-cli](https://github.com/BigstickCarpet/swagger-cli).
 
-To test locally, run `make run` and navigate to `http://127.0.0.1:8080`.
+To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:8080`.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ There is no strict style guide but please try to follow the example of the exist
 
 To build the full YAML, run `make build` and it will be output to `html/static/mattermost-openapi.yaml`. This will also check syntax using [swagger-cli](https://github.com/BigstickCarpet/swagger-cli).
 
+To test locally, run `make run` and navigate to `http://127.0.0.1:8080`.
+
 ## Deployment
 
 Deployment is handled automatically by our Jenkins CLI machine. When a pull request is merged it will automatically be deployed to [https://api.mattermost.com](https://api.mattermost.com).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is no strict style guide but please try to follow the example of the exist
 
 To build the full YAML, run `make build` and it will be output to `html/static/mattermost-openapi.yaml`. This will also check syntax using [swagger-cli](https://github.com/BigstickCarpet/swagger-cli).
 
-To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:8080`.
+To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:8080`. For any updates to the source files, re-run the same commands.
 
 ## Deployment
 

--- a/v4/source/bots.yaml
+++ b/v4/source/bots.yaml
@@ -178,7 +178,6 @@
         '403':
           $ref: '#/responses/Forbidden'
 
-
   /bots/{bot_user_id}/enable:
     post:
       tags:
@@ -206,7 +205,6 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
-
 
   /bots/{bot_user_id}/assign/{user_id}:
     post:
@@ -240,3 +238,148 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+
+  /bots/{bot_user_id}/icon:
+    get:
+      tags:
+        - bots
+      summary: Get bot's LHS icon
+      description: |
+        Get a bot's LHS icon image based on bot_user_id string parameter.
+        ##### Permissions
+        Must be logged in.
+        __Minimum server version__: 5.14
+      parameters:
+        - name: bot_user_id
+          in: path
+          description: Bot user ID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Bot's LHS icon image
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+        '500':
+          $ref: '#/responses/InternalServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            botUserID := "4xp9fdt77pncbef59f4k1qe83o"
+
+            data, resp := Client.GetBotIconImage(botUserID)
+    post:
+      tags:
+        - bots
+      summary: Set bot's LHS icon image
+      description: |
+        Set a bot's LHS icon image based on bot_user_id string parameter. Icon image must be SVG format, all other formats are rejected.
+        ##### Permissions
+        Must have `manage_bots` permission.
+        __Minimum server version__: 5.14
+      consumes: ["multipart/form-data"]
+      parameters:
+        - name: image
+          in: formData
+          description: SVG icon image to be uploaded
+          required: true
+          type: file
+        - name: bot_user_id
+          in: path
+          description: Bot user ID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: SVG icon image set successful
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '413':
+          $ref: '#/responses/TooLarge'
+        '500':
+          $ref: '#/responses/InternalServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import (
+              "io/ioutil"
+              "log"
+
+              "github.com/mattermost/mattermost-server/model"
+            )
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            data, err := ioutil.ReadFile("icon_image.svg")
+            if err != nil {
+              log.Fatal(err)
+            }
+
+            botUserID := "4xp9fdt77pncbef59f4k1qe83o"
+
+            ok, resp := Client.SetBotIconImage(botUserID, data)
+    delete:
+      tags:
+        - bots
+      summary: Delete bot's LHS icon image
+      description: |
+        Delete bot's LHS icon image based on bot_user_id string parameter.
+        ##### Permissions
+        Must have `manage_bots` permission.
+        __Minimum server version__: 5.14
+      parameters:
+        - name: bot_user_id
+          in: path
+          description: Bot user ID
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Icon image deletion successful
+          schema:
+            $ref: '#/definitions/StatusOK'
+        '400':
+          $ref: '#/responses/BadRequest'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
+        '500':
+          $ref: '#/responses/InternalServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            botUserID := "4xp9fdt77pncbef59f4k1qe83o"
+
+            ok, resp := Client.DeleteBotIconImage(botUserID)

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -401,6 +401,7 @@ x-tagGroups:
   - name: Endpoints
     tags:
       - users
+      - bots
       - teams
       - channels
       - posts


### PR DESCRIPTION
### Summary
- Added docs for `GET`, `POST`, `DELETE` on `/bots/{bot_user_id}/icon` route (https://github.com/mattermost/mattermost-server/pull/11423)
- Fixed `bots` section as it wasn't showing up in the final api documentation page
- Added `make run` target to run `redoc` server for local testing
- Updated README to include instructions on how to test locally


### Docs preview
![image](https://user-images.githubusercontent.com/25732808/60885213-0c8f9b00-a21d-11e9-9321-e19c62c4a472.png)

### README preview
![image](https://user-images.githubusercontent.com/25732808/60885358-68f2ba80-a21d-11e9-8de6-48fc93a818f6.png)
