### PR TITLE
MM-17412 Remove file_ids from update post API

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -195,9 +195,6 @@
               message:
                 description: The message text of the post
                 type: string
-              file_ids:
-                 description: The list of files attached to this post
-                 type: array
               has_reactions:
                 description: Set to `true` if the post has reactions to it
                 type: boolean


### PR DESCRIPTION
This was removed in https://github.com/mattermost/mattermost-server/pull/10540, but the documentation wasn't updated to reflect that