### PR TITLE
MM-15219 Add support for introduction text in interactive dialogs

### DIFF
--- a/v4/source/actions.yaml
+++ b/v4/source/actions.yaml
@@ -37,6 +37,9 @@
                   title:
                     type: string
                     description: Title of the dialog
+                  introduction_text:
+                    type: string
+                    description: Markdown formatted introductory paragraph
                   elements:
                     type: array
                     description: Input elements, see https://docs.mattermost.com/developer/interactive-dialogs.html#elements
@@ -101,7 +104,7 @@
               cancelled:
                 type: boolean
                 description: Set to true if the dialog was cancelled
-                
+
       responses:
         '200':
           description: Dialog submission successful
@@ -113,4 +116,3 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
-


### PR DESCRIPTION
#### Summary
Adds an optional field to the `model.Dialog` struct  called `introductionText` that can accept markdown formatted text.

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/12029