### PR TITLE
[MM-17754] add websocket event to docs

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -237,6 +237,7 @@ tags:
       - plugin_statuses_changed
       - post_deleted
       - post_edited
+      - post_unread
       - posted
       - preference_changed
       - preferences_changed

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -2257,3 +2257,35 @@
             userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
 
             userTermsOfService, resp := Client.GetUserTermsOfService(userID, "")
+
+  /users/sessions/revoke/all:
+    post:
+      tags:
+        - users
+      summary: Revoke all sessions from all users.
+      description: |
+        For any session currently on the server (including admin) it will be revoked.
+        Clients will be notified to log out users.
+
+        __Minimum server version__: 5.14
+
+        ##### Permissions
+        
+        Must have `manage_system` permission.
+
+      responses:
+        '200':
+          description: Sessions successfully revoked.
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            response, err := Client.RevokeSessionsFromAllUsers()


### PR DESCRIPTION
with the new mark as unread feature, there is a new websocket event: `post_unread`
I haven't marked a needed version as there seems to be no such feature for an item from a list