### PR TITLE
[MM-17754] add post_unread event to websocket

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -237,6 +237,7 @@ tags:
       - plugin_statuses_changed
       - post_deleted
       - post_edited
+      - post_unread
       - posted
       - preference_changed
       - preferences_changed


### PR DESCRIPTION
with the new mark as unread feature, there is a new websocket event: post_unread
I haven't marked a needed version as there seems to be no such feature for an item from a list