### PR TITLE
Adds the "link" type to the embed definition

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -308,7 +308,7 @@ definitions:
             type:
               type: string
               description: The type of content that is embedded in this point.
-              enum: ["image", "message_attachment", "opengraph"]
+              enum: ["image", "message_attachment", "opengraph", "link"]
             url:
               type: string
               description: The URL of the embedded content, if one exists.
@@ -2413,4 +2413,3 @@ definitions:
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'
-


### PR DESCRIPTION
#### Summary

This PR adds the "link" type to the embed API definition, to match the changes made as part of [this server PR](https://github.com/mattermost/mattermost-server/pull/11723).