### PR TITLE
fix websocket authentication wording

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -178,7 +178,7 @@ tags:
       }
       ```
 
-      If successful, you will receive a standard OK response from the webhook:
+      If successful, you will receive a standard OK response over the WebSocket connection:
 
       ```
       {


### PR DESCRIPTION
I assume `WebHooks` is incorrect here, since AFAIK
they have nothing to do with the websocket here.