### PR TITLE
Add missing `seq` to the example `hello` WebSocket Event

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -206,7 +206,8 @@ tags:
           "user_id": "ay5sq51sebfh58ktrce5ijtcwy",
           "channel_id": "",
           "team_id": ""
-        }
+        },
+        "seq": 0
       }
       ```
 


### PR DESCRIPTION
I seperated this one from my other PR, because I am not 100% sure if this is really correct.
Looking trough mattermost-server https://github.com/mattermost/mattermost-server/blob/7a665aacdd2f238b11cc0a8b7d12b0bf37dc606a/app/web_conn.go#L298
it seems that `seq` is always in that response. Not sure if it is always zero, but it was always zero in my case.