### PR TITLE
Get channel members = channel memberships and roles

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -1396,9 +1396,9 @@
     get:
       tags:
         - channels
-      summary: Get channel members for user
+      summary: Get channel memberships and roles for a user
       description: |
-        Get all channel members on a team for a user.
+        Get all channel memberships and associated membership roles (i.e. `channel_user`, `channel_admin`) for a user on a specific team.
         ##### Permissions
         Logged in as the user and `view_team` permission for the team. Having `manage_system` permission voids the previous requirements.
       parameters:


### PR DESCRIPTION
Updates docs to indicate that this endpoint returns a list of channels and associated roles for a user on a team, not a list of members (as the URL implies).