### PR TITLE
[MM-20015] Fix validation errors

### DIFF
--- a/v4/source/brand.yaml
+++ b/v4/source/brand.yaml
@@ -13,7 +13,6 @@
           schema:
             type: string
         '404':
-          description: No brand image uploaded
           $ref: '#/responses/NotFound'
         '501':
           $ref: '#/responses/NotImplemented'
@@ -98,7 +97,6 @@
         '403':
           $ref: '#/responses/Forbidden'
         '404':
-          description: No brand image uploaded
           $ref: '#/responses/NotFound'
       x-code-samples:
         - lang: 'Go'

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -279,8 +279,10 @@
                 description: The message text of the post
                 type: string
               file_ids:
-                 description: The list of files attached to this post
-                 type: array
+                description: The list of files attached to this post
+                type: array
+                items:
+                  type: string
               has_reactions:
                 description: Set to `true` if the post has reactions to it
                 type: boolean

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -15,10 +15,6 @@
             $ref: "#/definitions/StatusOK"
         '500':
           $ref: '#/responses/InternalServerError'
-          schema:
-            type: object
-            items:
-              type: string
       x-code-samples:
         - lang: 'Go'
           source: |


### PR DESCRIPTION
This PR will fix validation errors thrown by https://editor.swagger.io
We are using [swagger-cli](https://github.com/BigstickCarpet/swagger-cli) to validate the yaml file, but it is not able to detect those errors.

Fixes: 
https://mattermost.atlassian.net/browse/MM-20015
https://github.com/mattermost/mattermost-api-reference/issues/468