### PR TITLE
Doc for operations over non existent plugins

### DIFF
--- a/v4/source/plugins.yaml
+++ b/v4/source/plugins.yaml
@@ -228,6 +228,8 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
         '501':
           $ref: '#/responses/NotImplemented'
       x-code-samples:
@@ -270,6 +272,8 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+        '404':
+          $ref: '#/responses/NotFound'
         '501':
           $ref: '#/responses/NotImplemented'
       x-code-samples:


### PR DESCRIPTION
#### Summary

Add response codes 404 for operations over non existent plugins

- [x] Enabling plugin
- [x] Disabling plugin

For the case when deleting a non existent plugin it is already documented

#### Related issue

https://github.com/mattermost/mattermost-server/pull/11631
