### PR TITLE
MM-21356: Add set_online query param

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -8,6 +8,11 @@
         ##### Permissions
         Must have `create_post` permission for the channel the post is being created in.
       parameters:
+        - name: set_online
+          in: query
+          description: Whether to set the user status as online or not.
+          required: false
+          type: boolean
         - in: body
           name: post
           description: Post object to create


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This will decide whether to set the user status as online or not
when creating a post.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21356