### PR TITLE
MM 21071 - update docs for endpoint rename 

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2502,7 +2502,7 @@ definitions:
         description: The user id of the user that currently owns this bot.
         type: string
 
-  SvrBusy:
+  Server_Busy:
     type: object
     properties: 
       busy:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2502,6 +2502,23 @@ definitions:
         description: The user id of the user that currently owns this bot.
         type: string
 
+  SvrBusy:
+    type: object
+    properties: 
+      busy:
+        description: True if the server is marked as busy (under high load)
+        type: string
+        enum:
+          - true
+          - false
+      expires:
+        description: timestamp - number of seconds since Jan 1, 1970 UTC.
+        type: integer
+        format: int64
+      expires_ts: 
+        description: timestamp - human readable
+        type: string
+
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -654,6 +654,9 @@
       summary: Set the server busy (high load) flag
       description: |
         Marks the server as currently having high load which disables non-critical services such as search, statuses and typing notifications.
+
+        __Minimum server version__: 5.20
+
         ##### Permissions
         Must have `manage_system` permission.
       parameters:
@@ -681,12 +684,21 @@
             Client.Login("email@domain.com", "Password1")
 
             ok, resp := Client.SetServerBusy(300)
+        - lang: 'curl'
+          source: |
+            curl -X POST \
+              'http://your-mattermost-url.com/api/v4/svrbusy?secs=3600' \
+              -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
+
     get:
       tags:
         - system
       summary: Get server busy expiry time.
       description: |
         Gets the timestamp corresponding to when the server busy flag will be automatically cleared. 
+
+        __Minimum server version__: 5.20
+
         ##### Permissions
         Must have `manage_system` permission.
       responses:
@@ -706,6 +718,12 @@
 
             // expires is a time.Time
             expires, resp := Client.GetServerBusyExpires()
+        - lang: 'curl'
+          source: |
+            curl -X GET \
+              'http://your-mattermost-url.com/api/v4/svrbusy' \
+              -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
+              -H 'Content-Type: application/json'
 
   '/busy/clear':
     post:
@@ -714,6 +732,9 @@
       summary: Clears the server busy (high load) flag
       description: |
         Marks the server as not having high load which re-enables non-critical services such as search, statuses and typing notifications.
+
+        __Minimum server version__: 5.20
+
         ##### Permissions
         Must have `manage_system` permission.
       responses:
@@ -732,4 +753,9 @@
             Client.Login("email@domain.com", "Password1")
 
             ok, resp := Client.ClearServerBusy()
+        - lang: 'curl'
+          source: |
+            curl -X POST \
+              'http://your-mattermost-url.com/api/v4/svrbusy/clear' \
+              -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -646,3 +646,96 @@
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
+
+  '/busy/set':
+    post:
+      tags:
+        - system
+      summary: Set the server busy (high load) flag
+      description: |
+        Marks the server as currently having high load which disables non-critical services such as search, statuses and typing notifications.
+        ##### Permissions
+        Must have `manage_system` permission.
+      parameters:
+        - name: secs
+          in: query
+          required: false
+          description: Number of seconds until server is automatically marked as not busy.
+          default: "3600"
+          type: string
+      responses:
+        '200':
+          description: Server busy flag set successfully
+          schema:
+            $ref: "#/definitions/StatusOK"
+        '400':
+          $ref: '#/responses/BadRequest'
+        '403':
+          $ref: '#/responses/Forbidden'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            ok, resp := Client.SetServerBusy(300)
+
+  '/busy/clear':
+    post:
+      tags:
+        - system
+      summary: Clears the server busy (high load) flag
+      description: |
+        Marks the server as not having high load which re-enables non-critical services such as search, statuses and typing notifications.
+        ##### Permissions
+        Must have `manage_system` permission.
+      responses:
+        '200':
+          description: Server busy flag cleared successfully
+          schema:
+            $ref: "#/definitions/StatusOK"
+        '403':
+          $ref: '#/responses/Forbidden'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            ok, resp := Client.ClearServerBusy()
+
+  '/busy/expires':
+    get:
+      tags:
+        - system
+      summary: Get server busy expiry time.
+      description: |
+        Gets the timestamp corresponding to when the server busy flag will be automatically cleared. 
+        ##### Permissions
+        Must have `manage_system` permission.
+      responses:
+        '200':
+          description: Server busy expires timestamp retrieved successfully
+          schema:
+            type: object
+            properties: 
+              expires:
+                description: timestamp - number of seconds since Jan 1, 1970 UTC.
+                type: integer
+                format: int64
+        '403':
+          $ref: '#/responses/Forbidden'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            // expires is a time.Time
+            expires, resp := Client.GetServerBusyExpires()

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -725,7 +725,8 @@
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json'
 
-    delete:
+  '/server_busy/clear':
+    post:
       tags:
         - system
       summary: Clears the server busy (high load) flag
@@ -754,7 +755,7 @@
             ok, resp := Client.ClearServerBusy()
         - lang: 'curl'
           source: |
-            curl -X DELETE \
-              'http://your-mattermost-url.com/api/v4/server_busy' \
+            curl -X POST \
+              'http://your-mattermost-url.com/api/v4/server_busy/clear' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -725,8 +725,7 @@
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json'
 
-  '/server_busy/clear':
-    post:
+    delete:
       tags:
         - system
       summary: Clears the server busy (high load) flag
@@ -755,7 +754,7 @@
             ok, resp := Client.ClearServerBusy()
         - lang: 'curl'
           source: |
-            curl -X POST \
-              'http://your-mattermost-url.com/api/v4/server_busy/clear' \
+            curl -X DELETE \
+              'http://your-mattermost-url.com/api/v4/server_busy' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -647,7 +647,7 @@
         '403':
           $ref: '#/responses/Forbidden'
 
-  '/busy/set':
+  '/svrbusy':
     post:
       tags:
         - system
@@ -681,6 +681,31 @@
             Client.Login("email@domain.com", "Password1")
 
             ok, resp := Client.SetServerBusy(300)
+    get:
+      tags:
+        - system
+      summary: Get server busy expiry time.
+      description: |
+        Gets the timestamp corresponding to when the server busy flag will be automatically cleared. 
+        ##### Permissions
+        Must have `manage_system` permission.
+      responses:
+        '200':
+          description: Server busy expires timestamp retrieved successfully
+          schema:
+            $ref: '#/definitions/SvrBusy'
+        '403':
+          $ref: '#/responses/Forbidden'
+      x-code-samples:
+        - lang: 'Go'
+          source: |
+            import "github.com/mattermost/mattermost-server/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            // expires is a time.Time
+            expires, resp := Client.GetServerBusyExpires()
 
   '/busy/clear':
     post:
@@ -708,34 +733,3 @@
 
             ok, resp := Client.ClearServerBusy()
 
-  '/busy/expires':
-    get:
-      tags:
-        - system
-      summary: Get server busy expiry time.
-      description: |
-        Gets the timestamp corresponding to when the server busy flag will be automatically cleared. 
-        ##### Permissions
-        Must have `manage_system` permission.
-      responses:
-        '200':
-          description: Server busy expires timestamp retrieved successfully
-          schema:
-            type: object
-            properties: 
-              expires:
-                description: timestamp - number of seconds since Jan 1, 1970 UTC.
-                type: integer
-                format: int64
-        '403':
-          $ref: '#/responses/Forbidden'
-      x-code-samples:
-        - lang: 'Go'
-          source: |
-            import "github.com/mattermost/mattermost-server/model"
-
-            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
-            Client.Login("email@domain.com", "Password1")
-
-            // expires is a time.Time
-            expires, resp := Client.GetServerBusyExpires()

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -647,7 +647,7 @@
         '403':
           $ref: '#/responses/Forbidden'
 
-  '/svrbusy':
+  '/server_busy':
     post:
       tags:
         - system
@@ -660,7 +660,7 @@
         ##### Permissions
         Must have `manage_system` permission.
       parameters:
-        - name: secs
+        - name: seconds
           in: query
           required: false
           description: Number of seconds until server is automatically marked as not busy.
@@ -687,7 +687,7 @@
         - lang: 'curl'
           source: |
             curl -X POST \
-              'http://your-mattermost-url.com/api/v4/svrbusy?secs=3600' \
+              'http://your-mattermost-url.com/api/v4/server_busy?seconds=3600' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 
     get:
@@ -705,7 +705,7 @@
         '200':
           description: Server busy expires timestamp retrieved successfully
           schema:
-            $ref: '#/definitions/SvrBusy'
+            $ref: '#/definitions/Server_Busy'
         '403':
           $ref: '#/responses/Forbidden'
       x-code-samples:
@@ -721,11 +721,11 @@
         - lang: 'curl'
           source: |
             curl -X GET \
-              'http://your-mattermost-url.com/api/v4/svrbusy' \
+              'http://your-mattermost-url.com/api/v4/server_busy' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json'
 
-  '/busy/clear':
+  '/server_busy/clear':
     post:
       tags:
         - system
@@ -756,6 +756,6 @@
         - lang: 'curl'
           source: |
             curl -X POST \
-              'http://your-mattermost-url.com/api/v4/svrbusy/clear' \
+              'http://your-mattermost-url.com/api/v4/server_busy/clear' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request updates documentation for endpoint rename: `POST server_busy/clear` renamed to `DELETE server_busy.`

Depends on PR https://github.com/mattermost/mattermost-server/pull/13563

Rebased against PR https://github.com/mattermost/mattermost-api-reference/pull/489 which is not yet merged as of this submission.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21071
