### PR TITLE
Update link to JavaScript Driver

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -43,7 +43,7 @@ tags:
       The easiest way to interact with the Mattermost Web Service API is through a language specific driver.
 
       #### Official Drivers
-      * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
+      * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.ts)
       * [Mattermost Golang Driver](https://github.com/mattermost/mattermost-server/blob/master/model/client4.go)
 
       #### Community-built Drivers


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes a broken link to the JavaScript Driver, since the driver file was updated from `.js` to `.ts` in [this PR](https://github.com/mattermost/mattermost-redux/pull/936/files)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A
