### PR TITLE
Add php samples for bots documentation

### DIFF
--- a/v4/source/bots.yaml
+++ b/v4/source/bots.yaml
@@ -37,6 +37,33 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $resp = $driver->getBotModel()->createBot([
+                "username" => "userbot",
+                "display_name" => "AwesomeBot",
+                "description" => "test bot"
+            ]);
+
+            if ($resp->getStatusCode() == 200) {
+                $createdBot = json_decode($resp->getBody());
+            }
     get:
       tags:
         - bots
@@ -89,6 +116,34 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $resp = $driver->getBotModel()->getBots([
+                "page" => 0,
+                "per_page" => 60,
+                "include_deleted" => true,
+                "only_orphaned" => true,
+            ]);
+
+            if ($resp->getStatusCode() == 200) {
+                $bots = json_decode($resp->getBody());
+            }
   "/bots/{bot_user_id}":
     put:
       tags:
@@ -140,6 +195,35 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+            $resp = $driver->getBotModel()->patchBot($botUserID, [
+                "username" => "userbot2",
+                "display_name" => "AwesomeBot2",
+                "description" => "test bot2"
+            ]);
+
+            if ($resp->getStatusCode() == 200) {
+                $bot = json_decode($resp->getBody());
+            }
     get:
       tags:
         - bots
@@ -177,6 +261,33 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+            $resp = $driver->getBotModel()->getBot($botUserID, [
+                "include_deleted" => true,
+            ]);
+
+            if ($resp->getStatusCode() == 200) {
+                $bot = json_decode($resp->getBody());
+            }
   "/bots/{bot_user_id}/disable":
     post:
       tags:
@@ -207,6 +318,31 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+            $resp = $driver->getBotModel()->disableBot($botUserID);
+
+            if ($resp->getStatusCode() == 200) {
+                $disabledBot = json_decode($resp->getBody());
+            }
   "/bots/{bot_user_id}/enable":
     post:
       tags:
@@ -237,6 +373,31 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+            $resp = $driver->getBotModel()->enableBot($botUserID);
+
+            if ($resp->getStatusCode() == 200) {
+                $enabledBot = json_decode($resp->getBody());
+            }
   "/bots/{bot_user_id}/assign/{user_id}":
     post:
       tags:
@@ -273,6 +434,32 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: PHP
+          source: |
+            require 'vendor/autoload.php';
+
+            use \Gnello\Mattermost\Driver;
+
+            $container = new \Pimple\Container([
+                "driver" => [
+                    "url" => "https://your-mattermost-url.com",
+                    "login_id" => "email@domain.com",
+                    "password" => "Password1",
+                ]
+            ]);
+
+            $driver = new Driver($container);
+            $driver->authenticate();
+
+            $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+            $userID = "adWv1qPZmHdtxk7Lmqh6RtxWxS";
+
+            $resp = $driver->getBotModel()->assignBotToUser($botUserID, $userID);
+
+            if ($resp->getStatusCode() == 200) {
+                $assignedBot = json_decode($resp->getBody());
+            }
   "/bots/{bot_user_id}/icon":
     get:
       tags:
@@ -316,6 +503,30 @@
             botUserID := "4xp9fdt77pncbef59f4k1qe83o"
 
             data, resp := Client.GetBotIconImage(botUserID)
+        - lang: PHP
+          source: |
+             require 'vendor/autoload.php';
+
+             use \Gnello\Mattermost\Driver;
+
+             $container = new \Pimple\Container([
+                 "driver" => [
+                     "url" => "https://your-mattermost-url.com",
+                     "login_id" => "email@domain.com",
+                     "password" => "Password1",
+                 ]
+             ]);
+
+             $driver = new Driver($container);
+             $driver->authenticate();
+
+             $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+             $resp = $driver->getBotModel()->getBotIcon($botUserID);
+
+             if ($resp->getStatusCode() == 200) {
+                 $data = json_decode($resp->getBody());
+             }
     post:
       tags:
         - bots
@@ -388,6 +599,41 @@
             botUserID := "4xp9fdt77pncbef59f4k1qe83o"
 
             ok, resp := Client.SetBotIconImage(botUserID, data)
+        - lang: PHP
+          source: |
+              require 'vendor/autoload.php';
+
+              use \Gnello\Mattermost\Driver;
+
+              $container = new \Pimple\Container([
+                  "driver" => [
+                      "url" => "https://your-mattermost-url.com",
+                      "login_id" => "email@domain.com",
+                      "password" => "Password1",
+                  ]
+              ]);
+
+              $driver = new Driver($container);
+              $driver->authenticate();
+
+              $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+              $resource = fopen("icon_image.svg", 'rb');
+
+              if ($resource === false) {
+                  throw new \Exeption("Failure.");
+              }
+
+              $data = new \GuzzleHttp\Psr7\Stream($resource);
+
+              $resp = $driver->getBotModel()->setBotIcon($botUserID, [
+                  "image" => $data,
+              ]);
+
+              fclose($resource);
+
+              if ($resp->getStatusCode() == 200) {
+                  $ok = json_decode($resp->getBody())->status;
+              }
     delete:
       tags:
         - bots
@@ -434,3 +680,27 @@
             botUserID := "4xp9fdt77pncbef59f4k1qe83o"
 
             ok, resp := Client.DeleteBotIconImage(botUserID)
+        - lang: PHP
+          source: |
+              require 'vendor/autoload.php';
+
+              use \Gnello\Mattermost\Driver;
+
+              $container = new \Pimple\Container([
+                  "driver" => [
+                      "url" => "https://your-mattermost-url.com",
+                      "login_id" => "email@domain.com",
+                      "password" => "Password1",
+                  ]
+              ]);
+
+              $driver = new Driver($container);
+              $driver->authenticate();
+
+              $botUserID = "4xp9fdt77pncbef59f4k1qe83o";
+
+              $resp = $driver->getBotModel()->deleteBotIcon($botUserID);
+
+              if ($resp->getStatusCode() == 200) {
+                  $ok = json_decode($resp->getBody())->status;
+              }


### PR DESCRIPTION
**Summary**
Add PHP samples for bots endpoint documentation, based on the community-built [PHP Driver](https://github.com/gnello/php-mattermost-driver).