### PR TITLE
[MM-23264] Add documentation for channel member counts by group

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -2116,6 +2116,49 @@
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json' \
               -H 'X-Requested-With: XMLHttpRequest'
+  "/channels/{channel_id}/member_counts_by_group":
+    get:
+      tags:
+        - channels
+      summary: Channel members counts for each group that has atleast one member in the channel
+      description: >
+        Returns a set of ChannelMemberCountByGroup objects which contain a `group_id`, `channel_member_count` and a `channel_member_timezones_count`.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the given channel.
+
+        __Minimum server version__: 5.24
+      parameters:
+        - name: channel_id
+          in: path
+          description: Channel GUID
+          required: true
+          schema:
+            type: string
+        - name: include_timezones
+          in: query
+          description: Defines if member timezone counts should be returned or not
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: Successfully returns member counts by group for the given channel.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+      x-code-samples:
+        - lang: curl
+          source: >
+            curl -X GET \
+              'http://your-mattermost-url.com/api/v4/channels/3wyp678obid8pggjmhmhwpah1r/member_counts_by_group?include_timezones=true' \
+              -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
+              -H 'Content-Type: application/json' \
+              -H 'X-Requested-With: XMLHttpRequest'
   "/channels/{channel_id}/moderations":
     get:
       tags:
@@ -2176,7 +2219,7 @@
           required: true
           schema:
             type: string
-            
+
       responses:
         "200":
           description: "Retreived successfully"

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2649,6 +2649,19 @@ components:
           type: string
         roles:
           $ref: "#/components/schemas/ChannelModeratedRolesPatch"
+    ChannelMemberCountByGroup:
+      description: An object describing group member information in a channel
+      type: object
+      properties:
+        group_id:
+          type: string
+          description: ID of the group
+        channel_member_count:
+          type: number
+          description: Total number of group members in the channel
+        channel_member_timezones_count:
+          type: number
+          description: Total number of unique timezones for the group members in the channel
     LDAPGroupsPaged:
       description: A paged list of LDAP groups
       type: object


### PR DESCRIPTION
#### Summary
Adds documentation for the new endpoint to `/member_counts_by_group` added in the server PR here https://github.com/mattermost/mattermost-server/pull/14068

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23264