### PR TITLE
MM-24694: Add documentation for retrieving Groups By user id

### DIFF
--- a/v4/source/groups.yaml
+++ b/v4/source/groups.yaml
@@ -767,7 +767,10 @@
         summary: Get team groups by channels
         description: |
           Retrieve the set of groups associated with the channels in the given team grouped by channel.
-
+          
+          ##### Permissions
+          Must have `manage_system` permission or can access only for current user
+          
           __Minimum server version__: 5.11
         parameters:
           - name: team_id

--- a/v4/source/groups.yaml
+++ b/v4/source/groups.yaml
@@ -813,3 +813,32 @@
             $ref: "#/components/responses/InternalServerError"
           "501":
             $ref: "#/components/responses/NotImplemented"
+  "/users/{user_id}/groups":
+    get:
+      tags:
+        - groups
+      summary: Get groups for a userId
+      description: |
+        Retrieve the list of groups associated to the user
+
+        __Minimum server version__: 5.24
+      parameters:
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Group list retrieval successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Group"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "501":
+          $ref: "#/components/responses/NotImplemented"


### PR DESCRIPTION
#### Summary
Adds a new endpoint to return all groups for a user

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24694

#### Related PRs
https://github.com/mattermost/mattermost-server/pull/14443
