### PR TITLE
MM-25293: Document that since is mutually exclusive from other params

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -474,8 +474,9 @@
       summary: Get posts for a channel
       description: >
         Get a page of posts in a channel. Use the query parameters to modify the
-        behaviour of this endpoint. The parameters `since`, `before` and `after`
-        must not be used together.
+        behaviour of this endpoint. The parameter `since` must not be used with any of
+        `before`, `after`, `page`, and `per_page` parameters. If `since` is used, it will
+        always return all posts since that time limited till 1000.
 
         ##### Permissions
 


### PR DESCRIPTION
If since is used, other parameters are ignored and all posts from that time
are always returned.


#### Ticket link

https://mattermost.atlassian.net/browse/MM-25293