### PR TITLE
MM-22417: Clarify behavior of /channels/{channel_id}/posts endpoint

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -475,8 +475,12 @@
       description: >
         Get a page of posts in a channel. Use the query parameters to modify the
         behaviour of this endpoint. The parameter `since` must not be used with any of
-        `before`, `after`, `page`, and `per_page` parameters. If `since` is used, it will
-        always return all posts since that time limited till 1000.
+        `before`, `after`, `page`, and `per_page` parameters.
+
+        If `since` is used, it will always return all posts modified since that time,
+        ordered by their create time limited till 1000. A caveat with this parameter is that
+        there is no guarantee that the returned posts will be consecutive. It is left to the clients
+        to maintain state and fill any missing holes in the post order.
 
         ##### Permissions
 
@@ -503,7 +507,7 @@
         - name: since
           in: query
           description: Provide a non-zero value in Unix time milliseconds to select posts
-            created after that time
+            modified after that time
           schema:
             type: integer
         - name: before


### PR DESCRIPTION
It is known that the posts are actually returned from their update time
and not create time, and there can be gaps in the post order.

Although the gaps are not expected, but it is not known what will break
at this stage, so we just fix the documentation to clarify the behavior.
