### PR TITLE
Add missing user_id parameter to /users/{user_id}/typing

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -4155,7 +4155,7 @@
 
             response, err := Client.RevokeSessionsFromAllUsers()
 
-  /users/{user_id}/typing:
+  "/users/{user_id}/typing":
     post:
       tags:
         - users
@@ -4169,6 +4169,13 @@
 
         Must have `manage_system` permission to publish for any user other than oneself.
 
+      parameters:
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
#### Summary

The fix adds missing user_id parameter to `/users/{user_id}/typing`.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-api-reference/issues/542

