### PR TITLE
[MM-19640] Retrieve Compliance files from the System Console

### DIFF
--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -118,7 +118,7 @@
       summary: Download the results of a job.
       description: |
         Download the result of a single job.
-        __Minimum server version: 4.1__
+        __Minimum server version: 5.28__
         ##### Permissions
         Must have `manage_jobs` permission.
       parameters:

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -111,6 +111,32 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  "/jobs/{job_id}/download":
+    get:
+      tags:
+        - jobs
+      summary: Download the results of a job.
+      description: |
+        Download the result of a single job.
+        __Minimum server version: 4.1__
+        ##### Permissions
+        Must have `manage_jobs` permission.
+      parameters:
+        - name: job_id
+          in: path
+          description: Job GUID
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   "/jobs/{job_id}/cancel":
     post:
       tags:


### PR DESCRIPTION
Summary
Name job folders by job id rather than start and end times

Ticket Link
https://mattermost.atlassian.net/browse/MM-19640

Needed to let https://github.com/mattermost/mattermost-server/pull/14976 pass the Build CI tests