### PR TITLE
[MM-25652] Add documentation for /integrity local-mode API endpoint

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2812,6 +2812,48 @@ components:
         type: array
         items:
           $ref: "#/components/schemas/GroupWithSchemeAdmin"
+
+    OrphanedRecord:
+      description: an object containing information about an orphaned record.
+      type: object
+      properties:
+        parent_id:
+          type: string
+          description: the id of the parent relation (table) entry.
+        child_id:
+          type: string
+          description: the id of the child relation (table) entry.
+    RelationalIntegrityCheckData:
+      description: an object containing the results of a relational integrity check.
+      type: object
+      properties:
+        parent_name:
+          type: string
+          description: the name of the parent relation (table).
+        child_name:
+          type: string
+          description: the name of the child relation (table).
+        parent_id_attr:
+          type: string
+          description: the name of the attribute (column) containing the parent id.
+        child_id_attr:
+          type: string
+          description: the name of the attribute (column) containing the child id.
+        records:
+          description: the list of orphaned records found.
+          type: array
+          items:
+            $ref: "#/components/schemas/OrphanedRecord"
+    IntegrityCheckResult:
+      description: an object with the result of the integrity check.
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/RelationalIntegrityCheckData"
+        err:
+          type: string
+          description: a string value set in case of error.
+
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -1095,3 +1095,48 @@
                 format: binary
         "404":
           $ref: "#/components/responses/NotFound"
+  /integrity:
+    post:
+      tags:
+        - system
+      summary: Perform a database integrity check
+      description: >
+        Performs a database integrity check.
+
+
+        __Note__: This check may temporarily harm system performance.
+
+
+        __Minimum server version__: 5.28.0
+
+
+        __Local mode only__: This endpoint is only available through [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+      responses:
+        "200":
+          description: Integrity check successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IntegrityCheckResult"
+      x-code-samples:
+        - lang: Go
+          source: |
+            import (
+                "net"
+                "net/http"
+
+                "github.com/mattermost/mattermost-server/v5/model"
+            )
+
+            tr := &http.Transport{
+                Dial: func(network, addr string) (net.Conn, error) {
+                    return net.Dial("unix", socketPath)
+                },
+            }
+
+            Client := model.NewAPIv4Client("http://_")
+            Client.HttpClient = &http.Client{Transport: tr}
+
+            ok, resp := Client.CheckIntegrity()

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -1130,13 +1130,6 @@
                 "github.com/mattermost/mattermost-server/v5/model"
             )
 
-            tr := &http.Transport{
-                Dial: func(network, addr string) (net.Conn, error) {
-                    return net.Dial("unix", socketPath)
-                },
-            }
-
-            Client := model.NewAPIv4Client("http://_")
-            Client.HttpClient = &http.Client{Transport: tr}
+            Client := model.NewAPIv4SocketClient(socketPath)
 
             ok, resp := Client.CheckIntegrity()


### PR DESCRIPTION
#### Summary

PR adds documentation for the added `/integrity` local-mode API endpoint.

#### Ticket

https://mattermost.atlassian.net/browse/MM-25652

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/15033