### PR TITLE
Add bot_post_counts_day query to /analytics/old

### DIFF
--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -875,8 +875,8 @@
         - name: name
           in: query
           required: false
-          description: Possible values are "standard", "post_counts_day",
-            "user_counts_with_posts_day" or "extra_counts"
+          description: Possible values are "standard", "bot_post_counts_day",
+            "post_counts_day", "user_counts_with_posts_day" or "extra_counts"
           schema:
             type: string
             default: standard


### PR DESCRIPTION
#### Summary
"bot_post_counts_day" query seems to work fine, but it's missing in api document.
https://github.com/mattermost/mattermost-server/blob/master/app/analytics.go#L196

#### Ticket Link
There is no issue/ticket