### PR TITLE
[MM-27274] Restrict converting to private to create_private_channel permission

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -791,7 +791,7 @@
         __Minimum server version__: 4.10
 
         ##### Permissions
-        `manage_team` permission for the team of the channel.
+        Must have `manage_team` and `create_private_channel` permissions for the team of the channel.
       parameters:
         - name: channel_id
           in: path


### PR DESCRIPTION
#### Summary
- Update docs to reflect server changes made https://github.com/mattermost/mattermost-server/pull/15243
- Required since previously this endpoint allowed a team admin without create_private_channel permission to create a public channel and then convert it to private, effectively sidestepping the create private channel permission


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27274