### PR TITLE
[MM-26812] Add documentation for new upload API endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/posts.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/preferences.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/files.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/uploads.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/jobs.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/system.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/emoji.yaml >> $(V4_YAML)

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2860,6 +2860,12 @@ components:
         id:
           description: The unique identifier for the upload.
           type: string
+        type:
+          description: The type of the upload.
+          type: string
+          enum:
+            - attachment
+            - import
         create_at:
           description: The time the upload was created in milliseconds.
           type: integer

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2853,6 +2853,34 @@ components:
         err:
           type: string
           description: a string value set in case of error.
+    UploadSession:
+      description: an object containing information used to keep track of a file upload.
+      type: object
+      properties:
+        id:
+          description: The unique identifier for the upload.
+          type: string
+        create_at:
+          description: The time the upload was created in milliseconds.
+          type: integer
+          format: int64
+        user_id:
+          description: The ID of the user performing the upload.
+          type: string
+        channel_id:
+          description: The ID of the channel to upload to.
+          type: string
+        filename:
+          description: The name of the file to upload.
+          type: string
+        file_size:
+          description: The size of the file to upload in bytes.
+          type: integer
+          format: int64
+        file_offset:
+          description: The amount of data uploaded in bytes.
+          type: integer
+          format: int64
 
 externalDocs:
   description: Find out more about Mattermost

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -518,6 +518,8 @@ tags:
     description: Endpoints for creating, getting and interacting with posts.
   - name: files
     description: Endpoints for uploading and interacting with files.
+  - name: uploads
+    description: Endpoints for creating and performing file uploads.
   - name: preferences
     description: Endpoints for saving and modifying user preferences.
   - name: status
@@ -589,6 +591,7 @@ x-tagGroups:
       - channels
       - posts
       - files
+      - uploads
       - preferences
       - status
       - emoji

--- a/v4/source/uploads.yaml
+++ b/v4/source/uploads.yaml
@@ -1,0 +1,183 @@
+  "/uploads":
+    post:
+      tags:
+        - uploads
+      summary: Create an upload
+      description: >
+        Creates a new upload session.
+
+
+        __Minimum server version__: 5.28
+
+        ##### Permissions
+
+        Must have `upload_file` permission.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - channel_id
+                - filename
+                - file_size
+              properties:
+                channel_id:
+                  description: The ID of the channel to upload to.
+                  type: string
+                filename:
+                  description: The name of the file to upload.
+                  type: string
+                file_size:
+                  description: The size of the file to upload in bytes.
+                  type: integer
+                  format: int64
+        required: true
+      responses:
+        "201":
+          description: Upload creation successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadSession"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/TooLarge"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+      x-code-samples:
+        - lang: Go
+          source: >
+            import "github.com/mattermost/mattermost-server/v5/model"
+
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+            Client.Login("email@domain.com", "Password1")
+
+            us := &model.UploadSession{
+              ChannelId: "4i6jn8r483nnuqnibnmgz8jo4o",
+              Filename: "file.png",
+              FileSize: 512000,
+            }
+
+            us, response := Client.CreateUpload(us)
+        - lang: Curl
+          source: |
+            curl 'http://localhost:8065/api/v4/uploads' \                                                                                                          
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
+            -H 'Content-Type: application/json' \
+            --data-binary '{"channel_id": "4i6jn8r483nnuqnibnmgz8jo4o", "filename": "test.png", "file_size": 512000}'
+  "/uploads/{upload_id}":
+    get:
+      tags:
+        - uploads
+      summary: Get an upload session
+      description: |
+        Gets an upload session that has been previously created.
+
+        ##### Permissions
+        Must be logged in as the user who created the upload session.
+      parameters:
+        - name: upload_id
+          in: path
+          description: The ID of the upload session to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+      x-code-samples:
+        - lang: Go
+          source: >
+            import "github.com/mattermost/mattermost-server/v5/model"
+
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+            Client.Login("email@domain.com", "Password1")
+
+            us, response := Client.GetUpload("nuyrh9ymridqmenof7exe3a6aw")
+        - lang: Curl
+          source: |
+            curl 'http://localhost:8065/api/v4/uploads/nuyrh9ymridqmenof7exe3a6aw' \                                                                                            
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'
+    post:
+      tags:
+        - uploads
+      summary: Perform a file upload
+      description: |
+        Starts or resumes a file upload.  
+        To resume an existing (incomplete) upload, data should be sent starting from the offset specified in the upload session object.
+
+        ##### Permissions
+        Must be logged in as the user who created the upload session.
+      parameters:
+        - name: upload_id
+          in: path
+          description: The ID of the upload session the data belongs to.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Upload successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileInfo"
+        "204":
+          description: Upload incomplete
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/TooLarge"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+      x-code-samples:
+        - lang: Go
+          source: >
+            import (
+              "os"
+
+              "github.com/mattermost/mattermost-server/v5/model"
+            )
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            file, err := os.Open("file.png")
+            if err != nil {
+              fmt.Fprintf(os.Stderr, "%v\n", err)
+              return
+            }
+
+            info, err := Client.UploadData(us, file)
+        - lang: Curl
+          source: |
+            curl -X POST 'http://localhost:8065/api/v4/uploads/qyxbzmprrjbdpdaprsxm98m6qe' \
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' --data-binary @file.png

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -4322,3 +4322,53 @@
                 ChannelId: "channel_id",
                 ParentId: "post_id",
             })
+
+  "/users/{user_id}/uploads":
+    get:
+      tags:
+        - users
+      summary: Get uploads for a user
+      description: |
+        Gets all the upload sessions belonging to a user.  
+
+        __Minimum server version__: 5.28
+
+        ##### Permissions
+        Must be logged in as the user who created the upload sessions.
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user. This can also be "me" which will point to the current user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User's uploads retrieval successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UploadSession"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      x-code-samples:
+        - lang: Go
+          source: >
+            import "github.com/mattermost/mattermost-server/v5/model"
+
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+            Client.Login("email@domain.com", "Password1")
+
+            uss, response := Client.GetUploadsForUser("fc6suoon9pbbpmhrb9c967paxe")
+        - lang: Curl
+          source: |
+            curl 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/uploads' \ 
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \


### PR DESCRIPTION
#### Summary

Add documentation for new upload API endpoints.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26812

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/15252
