### PR TITLE
[MM-28537] Purge indexes should be tied to sysconsole_write_experimental

### DIFF
--- a/v4/source/bleve.yaml
+++ b/v4/source/bleve.yaml
@@ -13,7 +13,7 @@
 
         ##### Permissions
 
-        Must have `manage_system` permission.
+        Must have `sysconsole_write_experimental` permission.
       responses:
         "200":
           description: Indexes purged successfully.


### PR DESCRIPTION
#### Summary
- Related server PR https://github.com/mattermost/mattermost-server/pull/15557
- https://mattermost.atlassian.net/browse/MM-28537