### PR TITLE
[GH-15742] updated 'check system health' docs

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -3038,6 +3038,36 @@ components:
         title:
           description: "Notice title. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown."
           type: string
+    SystemStatusResponse:
+      type: object
+      properties:
+        AndroidLatestVersion:
+          description: Latest Android version supported
+          type: string
+        AndroidMinVersion:
+          description: Minimum Android version supported
+          type: string
+        DesktopLatestVersion:
+          description: Latest desktop version supported
+          type: string
+        DesktopMinVersion:
+          description: Minimum desktop version supported
+          type: string
+        IosLatestVersion:
+          description: Latest iOS version supported
+          type: string
+        IosMinVersion:
+          description: Minimum iOS version supported
+          type: string
+        database_status:
+          description: Status of database ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        filestore_status:
+          description: Status of filestore ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        status:
+          description: Status of server ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
 externalDocs:
   description: Find out more about Mattermost
   url: 'https://about.mattermost.com'

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -38,13 +38,20 @@
         ##### Permissions
 
         Must be logged in.
+      parameters:
+        - name: get_server_status
+          in: query
+          description: Check the status of the database and file storage as well
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: Status of the system
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StatusOK"
+                $ref: "#/components/schemas/SystemStatusResponse"
         "500":
           $ref: "#/components/responses/InternalServerError"
       x-code-samples:
@@ -57,6 +64,9 @@
 
             // GetPing
             status, resp := Client.GetPing()
+
+            // Get server status with database and storage checks
+            status, resp = Client.GetPingWithServerStatus()
   "/system/notices/{teamId}":
     get:
       tags:


### PR DESCRIPTION
#### Summary
Updated the API doc entry for `System -> Check system health` to include the `get_server_status` parameter, and response schema.

#### Ticket Link
Noticed while fixing https://github.com/mattermost/mattermost-server/pull/15752

