### PR TITLE
[MM-28422] Add /imports endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/actions.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/bots.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/cloud.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/imports.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/definitions.yaml >> $(V4_YAML)
 
 	@node_modules/.bin/swagger-cli validate $(V4_YAML)

--- a/v4/source/imports.yaml
+++ b/v4/source/imports.yaml
@@ -7,10 +7,10 @@
         Lists all available import files.
 
 
-        __Minimum server version__: 5.30
+        __Minimum server version__: 5.31
 
         ##### Permissions
-        
+
         Must have `manage_system` permissions.
       responses:
         "400":
@@ -34,5 +34,5 @@
             imports, response := Client.ListImports()
         - lang: Curl
           source: |
-            curl 'http://localhost:8065/api/v4/imports' \                                                                                            
+            curl 'http://localhost:8065/api/v4/imports' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'

--- a/v4/source/imports.yaml
+++ b/v4/source/imports.yaml
@@ -1,0 +1,38 @@
+  "/imports":
+    get:
+      tags:
+        - imports
+      summary: List import files
+      description: >
+        Lists all available import files.
+
+
+        __Minimum server version__: 5.30
+
+        ##### Permissions
+        
+        Must have `manage_system` permissions.
+      responses:
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      x-code-samples:
+        - lang: Go
+          source: >
+            import "github.com/mattermost/mattermost-server/v5/model"
+
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+            Client.Login("email@domain.com", "Password1")
+
+            imports, response := Client.ListImports()
+        - lang: Curl
+          source: |
+            curl 'http://localhost:8065/api/v4/imports' \                                                                                            
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -570,6 +570,8 @@ tags:
     description: Endpoints for interactive actions for use by integrations.
   - name: terms of service
     description: Endpoints for getting and updating custom terms of service.
+  - name: imports
+    description: Endpoints related to import files.
 x-tagGroups:
   - name: Overview
     tags:
@@ -617,6 +619,7 @@ x-tagGroups:
       - schemes
       - integration_actions
       - terms of service
+      - imports
 servers:
   - url: http://your-mattermost-url.com/api/v4
   - url: https://your-mattermost-url.com/api/v4


### PR DESCRIPTION
#### Summary

PR adds documentation for the new `/imports` API endpoint.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-28424

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/16062
