### PR TITLE
[MM-30016] Add user_id and creator_id to the webhook create endpoints

### DIFF
--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -23,7 +23,7 @@
                     the webhook payloads.
                 user_id:
                   type: string
-                  description: The ID of the owner of the webhook if different than the requester. Required in [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+                  description: The ID of the owner of the webhook if different than the requester. Required for [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
                 display_name:
                   type: string
                   description: The display name for this incoming webhook

--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -6,7 +6,9 @@
       description: |
         Create an incoming webhook for a channel.
         ##### Permissions
-        `manage_webhooks` for the channel the webhook is in.
+        `manage_webhooks` for the team the webhook is in.
+
+        `manage_others_incoming_webhooks` for the team the webhook is in if the user is different than the requester.
       requestBody:
         content:
           application/json:
@@ -19,6 +21,9 @@
                   type: string
                   description: The ID of a public channel or private group that receives
                     the webhook payloads.
+                user_id:
+                  type: string
+                  description: The ID of the owner of the webhook if different than the requester. Required in [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
                 display_name:
                   type: string
                   description: The display name for this incoming webhook
@@ -230,6 +235,8 @@
         Create an outgoing webhook for a team.
         ##### Permissions
         `manage_webhooks` for the team the webhook is in.
+
+        `manage_others_outgoing_webhooks` for the team the webhook is in if the user is different than the requester.
       requestBody:
         content:
           application/json:
@@ -246,6 +253,9 @@
                   type: string
                 channel_id:
                   description: The ID of a public channel that the webhook watchs
+                  type: string
+                creator_id:
+                  description: The ID of the owner of the webhook if different than the requester. Required in [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
                   type: string
                 description:
                   description: The description for this outgoing webhook


### PR DESCRIPTION
#### Summary
Updates the documentation of create incoming and outgoing webhooks to include the user and creator ids.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30016
https://mattermost.atlassian.net/browse/MM-30021

#### Related Pull Requests
- [Has server changes](https://github.com/mattermost/mattermost-server/pull/16425)