### PR TITLE
MM-31001 Add docs for remotecluster endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/roles.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/schemes.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/service_terms.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/remotecluster.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/opengraph.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/reactions.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/actions.yaml >> $(V4_YAML)

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -570,6 +570,8 @@ tags:
     description: Endpoints for interactive actions for use by integrations.
   - name: terms of service
     description: Endpoints for getting and updating custom terms of service.
+  - name: remotecluster
+    description: Endpoints used only by the remote cluster service.
 x-tagGroups:
   - name: Overview
     tags:
@@ -618,6 +620,7 @@ x-tagGroups:
       - schemes
       - integration_actions
       - terms of service
+      - remotecluster
 servers:
   - url: http://your-mattermost-url.com/api/v4
   - url: https://your-mattermost-url.com/api/v4

--- a/v4/source/remotecluster.yaml
+++ b/v4/source/remotecluster.yaml
@@ -1,0 +1,54 @@
+  /remotecluster/msg:
+    post:
+      tags:
+        - remotecluster
+      summary: Accept message from remote cluster. 
+      description: >
+        This API is used only by the Remote Cluster Service.
+
+        __Minimum server version__: 5.33
+      responses:
+        "200":
+          description: Message received.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /remotecluster/confirm_invite:
+    post:
+      tags:
+        - remotecluster
+      summary: Confirms a remote cluster invitation.
+      description: >
+        This API is used only by the Remote Cluster Service.
+
+        __Minimum server version__: 5.33
+      responses:
+        "200":
+          description: Invitation confirmed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /remotecluster/ping:
+    post:
+      tags:
+        - remotecluster
+      summary: Accepts a ping from a remote cluster.
+      description: >
+        This API is used only by the Remote Cluster Service.
+
+        __Minimum server version__: 5.33
+      responses:
+        "200":
+          description: Ping received.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+        "500":
+          $ref: "#/components/responses/InternalServerError"


### PR DESCRIPTION
#### Summary
This PR adds documentation for three new endpoints:

1. api/v4/remotecluster/msg
2. api/v4/remotecluster/confirm_invite
3. api/v4/remotecluster/ping

The documentation is purposefully sparse because these endpoints can only be used by the new Remote Cluster Service.  This service allows clusters to communicate with each other.

Ideally this documentation wouldn't be needed as it pollutes the API reference with API's that cannot possibly be used by developers or users, however builds will fail without it due to linter rules.

@wiersgallak If you agree this does not belong in the API Reference, I could open a ticket to figure out how to allow exceptions to the linter.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31001