### PR TITLE
Revert "MM-30558 - updated routes for thread related APIs (#590)"

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -4523,7 +4523,7 @@
     
               ok, response := Client.MigrateAuthToSaml(fromAuthService, usersMap, auto)
 
-  "/users/{user_id}/teams/{team_id}/threads":
+  "/users/{user_id}/threads":
    get:
     tags:
      - threads
@@ -4542,12 +4542,6 @@
         required: true
         schema:
          type: string
-      - name: team_id
-        in: path
-        description: The ID of the team in which the thread is.
-        required: true
-        schema:
-          type: string
       - name: since
         in: query
         description: Since filters the threads based on their LastUpdateAt timestamp.
@@ -4604,7 +4598,7 @@
           Client := model.NewAPIv4Client("https://your-mattermost-url.com")
           Client.Login("email@domain.com", "Password1")
 
-          uss, response := Client.GetUserThreads("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", model.GetUserThreadsOpts{
+          uss, response := Client.GetUserThreads("fc6suoon9pbbpmhrb9c967paxe", model.GetUserThreadsOpts{
                                                                                       Deleted: true,
                                                                                       Since: 123123,
                                                                                       Page: 0,
@@ -4614,11 +4608,11 @@
         source: |
           curl 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads' \
           -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/teams/{team_id}/threads/read":
+  "/users/{user_id}/threads/read/{timestamp}":
     put:
       tags:
         - threads
-      summary: Mark all threads that user is following as read
+      summary: Update all threads that user is following read state to the timestamp
       description: |
         Mark all threads that user is following as read
 
@@ -4633,12 +4627,12 @@
           required: true
           schema:
             type: string
-        - name: team_id
+        - name: timestamp
           in: path
-          description: The ID of the team in which the thread is.
+          description: The timestamp to which the thread's "last read" state will be reset.
           required: true
           schema:
-            type: string
+            type: integer
       responses:
         "200":
           description: User's thread update successful
@@ -4658,12 +4652,12 @@
 
           Client.Login("email@domain.com", "Password1")
 
-          uss, response := Client.UpdateThreadsReadForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe")
+          uss, response := Client.UpdateThreadsReadForUser("fc6suoon9pbbpmhrb9c967paxe", true)
       - lang: Curl
         source: |
           curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/read' \
           -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}/read/{timestamp}":
+  "/users/{user_id}/threads/{thread_id}/read/{timestamp}":
     put:
       tags:
         - threads
@@ -4679,12 +4673,6 @@
         - name: user_id
           in: path
           description: The ID of the user. This can also be "me" which will point to the current user.
-          required: true
-          schema:
-            type: string
-        - name: team_id
-          in: path
-          description: The ID of the team in which the thread is.
           required: true
           schema:
             type: string
@@ -4719,7 +4707,7 @@
 
             Client.Login("email@domain.com", "Password1")
 
-            uss, response := Client.UpdateThreadReadForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e" true)
+            uss, response := Client.UpdateThreadReadForUser("fc6suoon9pbbpmhrb9c967paxe", "f96cv0897624352346e" true)
         - lang: Curl
           source: |
             curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/read' \
@@ -4739,12 +4727,6 @@
         - name: user_id
           in: path
           description: The ID of the user. This can also be "me" which will point to the current user.
-          required: true
-          schema:
-            type: string
-        - name: team_id
-          in: path
-          description: The ID of the team in which the thread is.
           required: true
           schema:
             type: string
@@ -4773,12 +4755,12 @@
 
             Client.Login("email@domain.com", "Password1")
 
-            uss, response := Client.UpdateThreadReadForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e" false)
+            uss, response := Client.UpdateThreadReadForUser("fc6suoon9pbbpmhrb9c967paxe", "f96cv0897624352346e" false)
         - lang: Curl
           source: |
             curl -X DELETE 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/read' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}/following":
+  "/users/{user_id}/threads/{thread_id}/following":
     put:
       tags:
         - threads
@@ -4794,12 +4776,6 @@
         - name: user_id
           in: path
           description: The ID of the user. This can also be "me" which will point to the current user.
-          required: true
-          schema:
-            type: string
-        - name: team_id
-          in: path
-          description: The ID of the team in which the thread is.
           required: true
           schema:
             type: string
@@ -4828,7 +4804,7 @@
 
             Client.Login("email@domain.com", "Password1")
 
-            uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e" true)
+            uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "f96cv0897624352346e" true)
         - lang: Curl
           source: |
             curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/followin' \
@@ -4848,12 +4824,6 @@
         - name: user_id
           in: path
           description: The ID of the user. This can also be "me" which will point to the current user.
-          required: true
-          schema:
-            type: string
-        - name: team_id
-          in: path
-          description: The ID of the team in which the thread is.
           required: true
           schema:
             type: string
@@ -4882,7 +4852,7 @@
 
             Client.Login("email@domain.com", "Password1")
 
-            uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e" false)
+            uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "f96cv0897624352346e" false)
         - lang: Curl
           source: |
             curl -X DELETE 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/following' \


### PR DESCRIPTION
This reverts commit 8fd99d0477525aa686a3a27f4209ce65bb4d55f8.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

