### PR TITLE
[MM-31497] - Add spec for cloud/subscription/stats

### DIFF
--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -319,3 +319,26 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
+  /cloud/subscription/stats:
+    get:
+      tags:
+        - cloud
+      summary: GET endpoint for cloud subscription stats
+      description: >
+        An endpoint for that returns stats about a users subscription. For example remaining seats on a free tier
+
+        ##### Permissions
+
+        This endpoint should only be accessed in a Mattermost Cloud instance
+
+        __Minimum server version__: 5.30
+        __Note:__ This is intended for internal use and is subject to change.
+      responses:
+        "200":
+        description: Cloud subscription stats returned successfully
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionStats"
+        "500":
+          $ref: "#/components/responses/InternalServerError"

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -335,10 +335,10 @@
         __Note:__ This is intended for internal use and is subject to change.
       responses:
         "200":
-        description: Cloud subscription stats returned successfully
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionStats"
+          description: Cloud subscription stats returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionStats"
         "500":
           $ref: "#/components/responses/InternalServerError"

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -331,7 +331,7 @@
 
         This endpoint should only be accessed in a Mattermost Cloud instance
 
-        __Minimum server version__: 5.30
+        __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
       responses:
         "200":

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -325,7 +325,7 @@
         - cloud
       summary: GET endpoint for cloud subscription stats
       description: >
-        An endpoint for that returns stats about a users subscription. For example remaining seats on a free tier
+        An endpoint that returns stats about a user's subscription. For example remaining seats on a free tier
 
         ##### Permissions
 

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2646,7 +2646,6 @@ components:
       properties:
         remaining_seats:
           type: integer
-          format: int
         is_paid_tier:
           type: string
     Invoice:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2641,6 +2641,13 @@ components:
           type: integer
         dns:
           type: string
+    SubscriptionStats:
+      type: object
+      properties:
+        remaining_seats:
+          type: int
+        is_paid_tier:
+          type: string
     Invoice:
       type: object
       properties:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2645,7 +2645,8 @@ components:
       type: object
       properties:
         remaining_seats:
-          type: int
+          type: integer
+          format: int
         is_paid_tier:
           type: string
     Invoice:


### PR DESCRIPTION
#### Summary
This PR adds a new cloud only endpoint to obtain stats about the kind of subscription a user has.

#### Ticket Link
[MM-31497](https://mattermost.atlassian.net/browse/MM-31497?atlOrigin=eyJpIjoiMDJhMDQwOWM1ODZhNDMzM2IyNDE5ZjAxNDM1OTg4Y2UiLCJwIjoiaiJ9)

#### Related Pull Request
[https://github.com/mattermost/mattermost-server/pull/16786](https://github.com/mattermost/mattermost-server/pull/16786)
