### PR TITLE
[MM-32543] - Add spec for cloud/alert/admin

### DIFF
--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -343,14 +343,13 @@
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /cloud/alert/admin:
+  /subscription/limitreached/invite:
     post:
       tags:
         - cloud
-      summary: POST endpoint for triggering sending of over limit alerts to system admins
+      summary: POST endpoint for triggering sending emails to admin with request to upgrade workspace
       description: >
-        An endpoint that triggers sending emails to all sys admins to alert them about the free tier limitation
-
+        An endpoint that triggers sending emails to all sys admins to request them to upgrade the workspace
         ##### Permissions
 
         This endpoint should only be accessed in a Mattermost Cloud instance

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -359,8 +359,8 @@
       responses:
         "200":
           description: Atleast one sys admin received the an email
-        "413":
-          $ref: "#/components/responses/TooLarge"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "501":

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -359,8 +359,8 @@
       responses:
         "200":
           description: Atleast one sys admin received the an email
-        "429":
-          $ref: "#/components/responses/TooManyRequests"
+        "413":
+          $ref: "#/components/responses/TooLarge"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "501":

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -342,3 +342,27 @@
                 $ref: "#/components/schemas/SubscriptionStats"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /cloud/alert/admin:
+    post:
+      tags:
+        - cloud
+      summary: POST endpoint for triggering sending of over limit alerts to system admins
+      description: >
+        An endpoint that triggers sending emails to all sys admins to alert them about the free tier limitation
+
+        ##### Permissions
+
+        This endpoint should only be accessed in a Mattermost Cloud instance
+
+        __Minimum server version__: 5.34
+        __Note:__ This is intended for internal use and is subject to change.
+      responses:
+        "200":
+          description: Atleast one sys admin received the an email
+        "413":
+          $ref: "#/components/responses/TooLarge"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -358,7 +358,7 @@
         __Note:__ This is intended for internal use and is subject to change.
       responses:
         "200":
-          description: Atleast one sys admin received the an email
+          description: Email sent to at least one of the system administrators
         "413":
           $ref: "#/components/responses/TooLarge"
         "500":


### PR DESCRIPTION
#### Summary
This is the spec definition for the endpoint ```/api/v4/cloud/subscription/limitreached/invite``` that adds rate limited way for users to alert sysadmins to upgrade their cloud workspace


#### Ticket Link
[MM-32543](https://mattermost.atlassian.net/secure/RapidBoard.jspa?rapidView=79&projectKey=MM&modal=detail&selectedIssue=MM-32543&quickFilter=382)
