### PR TITLE
MM-33444 API docs for getremoteinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build-v4: .npminstall
 	@cat $(V4_SRC)/roles.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/schemes.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/service_terms.yaml >> $(V4_YAML)
+	@cat $(V4_SRC)/sharedchannels.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/opengraph.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/reactions.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/actions.yaml >> $(V4_YAML)

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -3138,6 +3138,20 @@ components:
         title:
           description: "Notice title. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown."
           type: string
+    RemoteClusterInfo:
+      type: object
+      properties:
+        display_name:
+          description: The display name for the remote cluster
+          type: string
+        create_at:
+          description: The time in milliseconds a remote cluster was created
+          type: integer
+          format: int64
+        last_ping_at:
+          description: The time in milliseconds a remote cluster was last pinged successfully
+          type: integer
+          format: int64
     SystemStatusResponse:
       type: object
       properties:

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -571,6 +571,8 @@ tags:
     description: Endpoints for creating, getting and updating and deleting schemes.
   - name: integration_actions
     description: Endpoints for interactive actions for use by integrations.
+  - name: shared channels
+    description: Endpoints for getting information about shared channels.
   - name: terms of service
     description: Endpoints for getting and updating custom terms of service.
   - name: imports
@@ -624,6 +626,7 @@ x-tagGroups:
       - roles
       - schemes
       - integration_actions
+      - shared channels
       - terms of service
       - imports
       - exports

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -5,6 +5,9 @@
       summary: Get remote cluster info by ID for user.
       description: |
         Get remote cluster info based on remoteId.
+
+        __Minimum server version__: 5.50
+
         ##### Permissions
         Must be authenticated and user must belong to at least one channel shared with the remote cluster.
       parameters:

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -1,4 +1,4 @@
-  "/sharedchannels/getremoteinfo/{remote_id}":
+  "/sharedchannels/remote_info/{remote_id}":
     get:
       tags:
         - shared channels

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -1,0 +1,48 @@
+  "/sharedchannels/getremoteinfo/{remote_id}":
+    get:
+      tags:
+        - shared channels
+      summary: Get remote cluster info by ID for user.
+      description: |
+        Get remote cluster info based on remoteId.
+        ##### Permissions
+        Must be authenticated and user must belong to at least one channel shared with the remote cluster.
+      parameters:
+        - name: remote_id
+          in: path
+          description: Remote Cluster GUID
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Remote cluster info retrieval successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemoteClusterInfo"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      x-code-samples:
+        - lang: Go
+          source: |
+            import "github.com/mattermost/mattermost-server/v5/model"
+
+            Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+            Client.Login("email@domain.com", "Password1")
+
+            remoteID := "4xp9fdt77pncbef59f4k1qe83o"
+
+            info, err := Client.GetRemoteClusterInfo(remoteID)
+        - lang: curl
+          source: |
+            curl -X POST \
+              'http://your-mattermost-url.com/api/v4/sharedchannels/getremote/4xp9fdt77pncbef59f4k1qe83o' \
+              -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
+


### PR DESCRIPTION
#### Summary
This PR adds API docs for new endpoint `/sharedchannels/getremoteinfo/{remote_id}`

Note: minimum version is set to 5.50 as a placeholder as we do not yet know when shared channels will be released.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33444

Implementation: https://github.com/mattermost/mattermost-server/pull/17063