### PR TITLE
Adding 200 user limit to channel members

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -1512,7 +1512,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of members per page.
+          description: The number of members per page. There is a maximum limit of 200 members.
           schema:
             type: integer
             default: 60


### PR DESCRIPTION
Documents the 200 member limit for `/channels/{channel_id}/members`