### PR TITLE
Adding operationIds to API documentation

### DIFF
--- a/v4/source/actions.yaml
+++ b/v4/source/actions.yaml
@@ -10,7 +10,7 @@
         information on interactive dialogs.
 
         __Minimum server version: 5.6__
-      operationId: OpenDialog
+      operationId: OpenInteractiveDialog
       requestBody:
         content:
           application/json:
@@ -82,7 +82,7 @@
         information on interactive dialogs.
 
         __Minimum server version: 5.6__
-      operationId: SubmitDialog
+      operationId: SubmitInteractiveDialog
       requestBody:
         content:
           application/json:

--- a/v4/source/actions.yaml
+++ b/v4/source/actions.yaml
@@ -10,6 +10,7 @@
         information on interactive dialogs.
 
         __Minimum server version: 5.6__
+      operationId: OpenDialog
       requestBody:
         content:
           application/json:
@@ -81,6 +82,7 @@
         information on interactive dialogs.
 
         __Minimum server version: 5.6__
+      operationId: SubmitDialog
       requestBody:
         content:
           application/json:

--- a/v4/source/bleve.yaml
+++ b/v4/source/bleve.yaml
@@ -14,6 +14,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_experimental` permission.
+      operationId: PurgeBleveIndexes
       responses:
         "200":
           description: Indexes purged successfully.

--- a/v4/source/bots.yaml
+++ b/v4/source/bots.yaml
@@ -8,6 +8,7 @@
         ##### Permissions
         Must have `create_bot` permission.
         __Minimum server version__: 5.10
+      operationId: CreateBot
       requestBody:
           description: Bot to be created
           required: true
@@ -76,6 +77,7 @@
         Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are managing.
 
         __Minimum server version__: 5.10
+      operationId: GetBots
       parameters:
         - name: page
           in: query
@@ -159,6 +161,7 @@
         Must have `manage_bots` permission. 
 
         __Minimum server version__: 5.10
+      operationId: PatchBot
       parameters:
         - name: bot_user_id
           in: path
@@ -236,6 +239,7 @@
         Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are managing.
 
         __Minimum server version__: 5.10
+      operationId: GetBot
       parameters:
         - name: bot_user_id
           in: path
@@ -298,6 +302,7 @@
         ##### Permissions
         Must have `manage_bots` permission. 
         __Minimum server version__: 5.10
+      operationId: DisableBot
       parameters:
         - name: bot_user_id
           in: path
@@ -353,6 +358,7 @@
         ##### Permissions
         Must have `manage_bots` permission. 
         __Minimum server version__: 5.10
+      operationId: EnableBot
       parameters:
         - name: bot_user_id
           in: path
@@ -408,6 +414,7 @@
         ##### Permissions
         Must have `manage_bots` permission. 
         __Minimum server version__: 5.10
+      operationId: AssignBotToUser
       parameters:
         - name: bot_user_id
           in: path
@@ -470,6 +477,7 @@
         ##### Permissions
         Must be logged in.
         __Minimum server version__: 5.14
+      operationId: GetBotIcon
       parameters:
         - name: bot_user_id
           in: path
@@ -540,6 +548,7 @@
         Must have `manage_bots` permission.
 
         __Minimum server version__: 5.14
+      operationId: SetBotIcon
       parameters:
         - name: bot_user_id
           in: path
@@ -643,6 +652,7 @@
         ##### Permissions
         Must have `manage_bots` permission.
         __Minimum server version__: 5.14
+      operationId: DeleteBotIcon
       parameters:
         - name: bot_user_id
           in: path
@@ -717,6 +727,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: ConvertBotToUser
       parameters:
         - name: bot_user_id
           in: path

--- a/v4/source/bots.yaml
+++ b/v4/source/bots.yaml
@@ -414,7 +414,7 @@
         ##### Permissions
         Must have `manage_bots` permission. 
         __Minimum server version__: 5.10
-      operationId: AssignBotToUser
+      operationId: AssignBot
       parameters:
         - name: bot_user_id
           in: path
@@ -477,7 +477,7 @@
         ##### Permissions
         Must be logged in.
         __Minimum server version__: 5.14
-      operationId: GetBotIcon
+      operationId: GetBotIconImage
       parameters:
         - name: bot_user_id
           in: path
@@ -548,7 +548,7 @@
         Must have `manage_bots` permission.
 
         __Minimum server version__: 5.14
-      operationId: SetBotIcon
+      operationId: SetBotIconImage
       parameters:
         - name: bot_user_id
           in: path
@@ -652,7 +652,7 @@
         ##### Permissions
         Must have `manage_bots` permission.
         __Minimum server version__: 5.14
-      operationId: DeleteBotIcon
+      operationId: DeleteBotIconImage
       parameters:
         - name: bot_user_id
           in: path

--- a/v4/source/brand.yaml
+++ b/v4/source/brand.yaml
@@ -10,6 +10,7 @@
         ##### Permissions
 
         No permission required.
+      operationId: GetBrandImage
       responses:
         "200":
           description: Brand image retrieval successful
@@ -39,6 +40,7 @@
         Uploads a brand image.
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: UploadBrandImage
       requestBody:
         content:
           multipart/form-data:
@@ -101,6 +103,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version: 5.6__
+      operationId: DeleteBrandImage
       responses:
         "200":
           description: Brand image succesfully deleted

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -6,7 +6,7 @@
       description: |
         ##### Permissions
         `manage_system`
-      operationId: GetChannels
+      operationId: GetAllChannels
       parameters:
       - name: not_associated_to_group
         in: query
@@ -136,7 +136,7 @@
         ##### Permissions
 
         Must be one of the two users and have `create_direct_channel` permission. Having the `manage_system` permission voids the previous requirements.
-      operationId: CreateDirectMessageChannel
+      operationId: CreateDirectChannel
       requestBody:
         content:
           application/json:
@@ -182,7 +182,7 @@
         ##### Permissions
 
         Must have `create_group_channel` permission.
-      operationId: CreateGroupMessageChannel
+      operationId: CreateGroupChannel
       requestBody:
         content:
           application/json:
@@ -236,7 +236,7 @@
         Channels that are associated (via GroupChannel records) to a given group can be excluded from the results
 
         with the `not_associated_to_group` parameter and a group id string.
-      operationId: SearchChannelsAcrossTeams
+      operationId: SearchAllChannels
       requestBody:
         content:
           application/json:
@@ -405,7 +405,7 @@
         Get a list of public channels on a team by id.
         ##### Permissions
         `view_team` for the team the channels are on.
-      operationId: GetChannelsByIds
+      operationId: GetPublicChannelsByIdsForTeam
       parameters:
         - name: team_id
           in: path
@@ -465,7 +465,7 @@
 
         ##### Permissions
         Must have the `read_channel` permission.
-      operationId: GetChannelTimezones
+      operationId: GetChannelMembersTimezones
       parameters:
         - name: channel_id
           in: path
@@ -957,7 +957,7 @@
         Get statistics for a channel.
         ##### Permissions
         Must have the `read_channel` permission.
-      operationId: GetChannelStatistics
+      operationId: GetChannelStats
       parameters:
         - name: channel_id
           in: path
@@ -993,7 +993,7 @@
         - channels
       summary: Get a channel's pinned posts
       description: Get a list of pinned posts for channel.
-      operationId: GetChannelPinnedPosts
+      operationId: GetPinnedPosts
       parameters:
         - name: channel_id
           in: path
@@ -1035,7 +1035,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: GetPublicChannels
+      operationId: GetPublicChannelsForTeam
       parameters:
         - name: team_id
           in: path
@@ -1097,7 +1097,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: GetPrivateChannels
+      operationId: GetPrivateChannelsForTeam
       parameters:
         - name: team_id
           in: path
@@ -1157,7 +1157,7 @@
 
 
         __Minimum server version__: 3.10
-      operationId: GetDeletedChannels
+      operationId: GetDeletedChannelsForTeam
       parameters:
         - name: team_id
           in: path
@@ -1210,7 +1210,7 @@
         ##### Permissions
 
         Must have the `list_team_channels` permission.
-      operationId: AutocompleteChannels
+      operationId: AutocompleteChannelsForTeam
       parameters:
         - name: team_id
           in: path
@@ -1257,7 +1257,7 @@
         ##### Permissions
 
         Must have the `list_team_channels` permission.
-      operationId: AutocompleteChannelsForSearch
+      operationId: AutocompleteChannelsForTeamForSearch
       parameters:
         - name: team_id
           in: path
@@ -1876,7 +1876,7 @@
         ##### Permissions
 
         Must be authenticated and have the `manage_channel_roles` permission.
-      operationId: UpdateSchemeDerivedRolesOfChannelMember
+      operationId: UpdateChannelMemberSchemeRoles
       parameters:
         - name: channel_id
           in: path
@@ -1932,7 +1932,7 @@
         ##### Permissions
 
         Must be logged in as the user or have `edit_other_users` permission.
-      operationId: UpdateChannelNotifications
+      operationId: UpdateChannelNotifyProps
       parameters:
         - name: channel_id
           in: path
@@ -2074,7 +2074,7 @@
         ##### Permissions
 
         Logged in as the user and `view_team` permission for the team. Having `manage_system` permission voids the previous requirements.
-      operationId: GetChannelMembershipsForUser
+      operationId: GetChannelMembersForUser
       parameters:
         - name: user_id
           in: path
@@ -2383,7 +2383,7 @@
         Must have `read_channel` permission for the given channel.
 
         __Minimum server version__: 5.24
-      operationId: ChannelMembersCountsByGroup
+      operationId: GetChannelMemberCountsByGroup
       parameters:
         - name: channel_id
           in: path
@@ -2426,7 +2426,7 @@
 
 
         __Minimum server version__: 5.22
-      operationId: GetChannelModerationInformation
+      operationId: GetChannelModerations
       parameters:
         - name: channel_id
           in: path
@@ -2461,7 +2461,7 @@
 
 
         __Minimum server version__: 5.22
-      operationId: UpdateChannelModerationSettings
+      operationId: PatchChannelModerations
       requestBody:
         required: true
         content:
@@ -2506,7 +2506,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: GetUserSidebarCategories
+      operationId: GetSidebarCategoriesForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2549,7 +2549,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: CreateUserSidebarCategory
+      operationId: CreateSidebarCategoryForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2597,7 +2597,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: UpdateUserSidebarCategories
+      operationId: UpdateSidebarCategoriesForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2648,7 +2648,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: GetUserSidebarCategoryOrder
+      operationId: GetSidebarCategoryOrderForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2692,7 +2692,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: UpdateUserSidebarCategoryOrder
+      operationId: UpdateSidebarCategoryOrderForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2744,7 +2744,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: GetSidebarCategory
+      operationId: GetSidebarCategoryForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2791,7 +2791,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: UpdateSidebarCategory
+      operationId: UpdateSidebarCategoryForTeamForUser
       parameters:
         - name: team_id
           in: path
@@ -2845,7 +2845,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
-      operationId: DeleteSidebarCategory
+      operationId: RemoveSidebarCategoryForTeamForUser
       parameters:
         - name: team_id
           in: path

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -6,6 +6,7 @@
       description: |
         ##### Permissions
         `manage_system`
+      operationId: GetChannels
       parameters:
       - name: not_associated_to_group
         in: query
@@ -61,6 +62,7 @@
         ##### Permissions
 
         If creating a public channel, `create_public_channel` permission is required. If creating a private channel, `create_private_channel` permission is required.
+      operationId: CreateChannel
       requestBody:
         content:
           application/json:
@@ -134,6 +136,7 @@
         ##### Permissions
 
         Must be one of the two users and have `create_direct_channel` permission. Having the `manage_system` permission voids the previous requirements.
+      operationId: CreateDirectMessageChannel
       requestBody:
         content:
           application/json:
@@ -179,6 +182,7 @@
         ##### Permissions
 
         Must have `create_group_channel` permission.
+      operationId: CreateGroupMessageChannel
       requestBody:
         content:
           application/json:
@@ -232,6 +236,7 @@
         Channels that are associated (via GroupChannel records) to a given group can be excluded from the results
 
         with the `not_associated_to_group` parameter and a group id string.
+      operationId: SearchChannelsAcrossTeams
       requestBody:
         content:
           application/json:
@@ -352,6 +357,7 @@
 
 
         __Minimum server version__: 5.14
+      operationId: SearchGroupChannels
       requestBody:
         content:
           application/json:
@@ -399,6 +405,7 @@
         Get a list of public channels on a team by id.
         ##### Permissions
         `view_team` for the team the channels are on.
+      operationId: GetChannelsByIds
       parameters:
         - name: team_id
           in: path
@@ -458,6 +465,7 @@
 
         ##### Permissions
         Must have the `read_channel` permission.
+      operationId: GetChannelTimezones
       parameters:
         - name: channel_id
           in: path
@@ -498,6 +506,7 @@
         Get channel from the provided channel id string.
         ##### Permissions
         `read_channel` permission for the channel.
+      operationId: GetChannel
       parameters:
         - name: channel_id
           in: path
@@ -538,6 +547,7 @@
         ##### Permissions
 
         If updating a public channel, `manage_public_channel_members` permission is required. If updating a private channel, `manage_private_channel_members` permission is required.
+      operationId: UpdateChannel
       parameters:
         - name: channel_id
           in: path
@@ -623,6 +633,7 @@
         `delete_private_channel` permission if the channel is private,
 
         or have `manage_system` permission.
+      operationId: DeleteChannel
       parameters:
         - name: channel_id
           in: path
@@ -666,6 +677,7 @@
         ##### Permissions
 
         If updating a public channel, `manage_public_channel_members` permission is required. If updating a private channel, `manage_private_channel_members` permission is required.
+      operationId: PatchChannel
       parameters:
         - name: channel_id
           in: path
@@ -748,6 +760,7 @@
         `manage_team` permission for the channels team on version < 5.28.
         `convert_public_channel_to_private` permission for the channel if updating privacy to 'P' on version >= 5.28.
         `convert_private_channel_to_public` permission for the channel if updating privacy to 'O' on version >= 5.28.
+      operationId: UpdateChannelPrivacy
       parameters:
         - name: channel_id
           in: path
@@ -816,6 +829,7 @@
         ##### Permissions
         `manage_team` permission for the channels team on version < 5.28.
         `convert_public_channel_to_private` permission for the channel on version >= 5.28.
+      operationId: ConvertChannelToPrivate
       parameters:
         - name: channel_id
           in: path
@@ -863,6 +877,7 @@
 
         ##### Permissions
         `manage_team` permission for the team of the channel.
+      operationId: RestoreChannel
       parameters:
         - name: channel_id
           in: path
@@ -896,6 +911,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: MoveChannel
       parameters:
         - name: channel_id
           in: path
@@ -941,6 +957,7 @@
         Get statistics for a channel.
         ##### Permissions
         Must have the `read_channel` permission.
+      operationId: GetChannelStatistics
       parameters:
         - name: channel_id
           in: path
@@ -976,6 +993,7 @@
         - channels
       summary: Get a channel's pinned posts
       description: Get a list of pinned posts for channel.
+      operationId: GetChannelPinnedPosts
       parameters:
         - name: channel_id
           in: path
@@ -1017,6 +1035,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: GetPublicChannels
       parameters:
         - name: team_id
           in: path
@@ -1078,6 +1097,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: GetPrivateChannels
       parameters:
         - name: team_id
           in: path
@@ -1137,6 +1157,7 @@
 
 
         __Minimum server version__: 3.10
+      operationId: GetDeletedChannels
       parameters:
         - name: team_id
           in: path
@@ -1189,6 +1210,7 @@
         ##### Permissions
 
         Must have the `list_team_channels` permission.
+      operationId: AutocompleteChannels
       parameters:
         - name: team_id
           in: path
@@ -1235,6 +1257,7 @@
         ##### Permissions
 
         Must have the `list_team_channels` permission.
+      operationId: AutocompleteChannelsForSearch
       parameters:
         - name: team_id
           in: path
@@ -1280,6 +1303,7 @@
 
 
         In server version 5.16 and later, a user without the `list_team_channels` permission will be able to use this endpoint, with the search results limited to the channels that the user is a member of.
+      operationId: SearchChannels
       parameters:
         - name: team_id
           in: path
@@ -1348,6 +1372,7 @@
 
 
         In server version 5.18 and later, a user without the `list_team_channels` permission will be able to use this endpoint, with the search results limited to the channels that the user is a member of.
+      operationId: SearchArchivedChannels
       parameters:
         - name: team_id
           in: path
@@ -1406,6 +1431,7 @@
         Gets channel from the provided team id and channel name strings.
         ##### Permissions
         `read_channel` permission for the channel.
+      operationId: GetChannelByName
       parameters:
         - name: team_id
           in: path
@@ -1460,6 +1486,7 @@
         Gets a channel from the provided team name and channel name strings.
         ##### Permissions
         `read_channel` permission for the channel.
+      operationId: GetChannelByNameForTeamName
       parameters:
         - name: team_name
           in: path
@@ -1514,6 +1541,7 @@
         Get a page of members for a channel.
         ##### Permissions
         `read_channel` permission for the channel.
+      operationId: GetChannelMembers
       parameters:
         - name: channel_id
           in: path
@@ -1566,6 +1594,7 @@
         - channels
       summary: Add user to channel
       description: Add a user to a channel by creating a channel member object.
+      operationId: AddChannelMember
       parameters:
         - name: channel_id
           in: path
@@ -1629,6 +1658,7 @@
         Get a list of channel members based on the provided user ids.
         ##### Permissions
         Must have the `read_channel` permission.
+      operationId: GetChannelMembersByIds
       parameters:
         - name: channel_id
           in: path
@@ -1682,6 +1712,7 @@
         Get a channel member.
         ##### Permissions
         `read_channel` permission for the channel.
+      operationId: GetChannelMember
       parameters:
         - name: channel_id
           in: path
@@ -1732,6 +1763,7 @@
         `manage_public_channel_members` permission if the channel is public.
 
         `manage_private_channel_members` permission if the channel is private.
+      operationId: RemoveUserFromChannel
       parameters:
         - name: channel_id
           in: path
@@ -1776,6 +1808,7 @@
         Update a user's roles for a channel.
         ##### Permissions
         Must have `manage_channel_roles` permission for the channel.
+      operationId: UpdateChannelRoles
       parameters:
         - name: channel_id
           in: path
@@ -1843,6 +1876,7 @@
         ##### Permissions
 
         Must be authenticated and have the `manage_channel_roles` permission.
+      operationId: UpdateSchemeDerivedRolesOfChannelMember
       parameters:
         - name: channel_id
           in: path
@@ -1898,6 +1932,7 @@
         ##### Permissions
 
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: UpdateChannelNotifications
       parameters:
         - name: channel_id
           in: path
@@ -1968,6 +2003,7 @@
 
 
         __Response only includes `last_viewed_at_times` in Mattermost server 4.3 and newer.__
+      operationId: ViewChannel
       parameters:
         - in: path
           name: user_id
@@ -2038,6 +2074,7 @@
         ##### Permissions
 
         Logged in as the user and `view_team` permission for the team. Having `manage_system` permission voids the previous requirements.
+      operationId: GetChannelMembershipsForUser
       parameters:
         - name: user_id
           in: path
@@ -2090,6 +2127,7 @@
         ##### Permissions
 
         Logged in as the user, or have `edit_other_users` permission, and `view_team` permission for the team.
+      operationId: GetChannelsForTeamForUser
       parameters:
         - name: user_id
           in: path
@@ -2156,6 +2194,7 @@
         ##### Permissions
 
         Must be logged in as user and have the `read_channel` permission, or have `edit_other_usrs` permission.
+      operationId: GetChannelUnread
       parameters:
         - name: user_id
           in: path
@@ -2213,6 +2252,7 @@
 
 
         __Minimum server version__: 4.10
+      operationId: UpdateChannelScheme
       parameters:
         - name: channel_id
           in: path
@@ -2285,6 +2325,7 @@
 
 
         __Minimum server version__: 5.14
+      operationId: ChannelMembersMinusGroupMembers
       parameters:
         - name: channel_id
           in: path
@@ -2342,6 +2383,7 @@
         Must have `read_channel` permission for the given channel.
 
         __Minimum server version__: 5.24
+      operationId: ChannelMembersCountsByGroup
       parameters:
         - name: channel_id
           in: path
@@ -2384,6 +2426,7 @@
 
 
         __Minimum server version__: 5.22
+      operationId: GetChannelModerationInformation
       parameters:
         - name: channel_id
           in: path
@@ -2418,6 +2461,7 @@
 
 
         __Minimum server version__: 5.22
+      operationId: UpdateChannelModerationSettings
       requestBody:
         required: true
         content:
@@ -2462,6 +2506,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: GetUserSidebarCategories
       parameters:
         - name: team_id
           in: path
@@ -2504,6 +2549,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: CreateUserSidebarCategory
       parameters:
         - name: team_id
           in: path
@@ -2551,6 +2597,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: UpdateUserSidebarCategories
       parameters:
         - name: team_id
           in: path
@@ -2601,6 +2648,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: GetUserSidebarCategoryOrder
       parameters:
         - name: team_id
           in: path
@@ -2644,6 +2692,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: UpdateUserSidebarCategoryOrder
       parameters:
         - name: team_id
           in: path
@@ -2695,6 +2744,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: GetSidebarCategory
       parameters:
         - name: team_id
           in: path
@@ -2741,6 +2791,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: UpdateSidebarCategory
       parameters:
         - name: team_id
           in: path
@@ -2794,6 +2845,7 @@
         ##### Permissions
 
         Must be authenticated and have the `list_team_channels` permission.
+      operationId: DeleteSidebarCategory
       parameters:
         - name: team_id
           in: path

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -12,6 +12,7 @@
 
         __Minimum server version__: 5.28
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetCloudProducts
       responses:
         "200":
           description: Cloud products returned successfully
@@ -44,6 +45,7 @@
         __Minimum server version__: 5.28
         __Note:__: This is intended for internal use and is subject to change.
 
+      operationId: CreateCustomerSetupPaymentIntent
       responses:
         "201":
           description: Payment setup intented created
@@ -74,6 +76,7 @@
         __Minimum server version__: 5.28
 
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: CompletePaymentSetupIntent
       requestBody:
         content:
           multipart/form-data:
@@ -109,6 +112,7 @@
 
         __Minimum server version__: 5.28
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetCloudCustomer
       responses:
         "200":
           description: Cloud customer returned successfully
@@ -137,6 +141,7 @@
 
         __Minimum server version__: 5.29
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: UpdateCloudCustomer
       requestBody:
         content:
           application/json:
@@ -184,6 +189,7 @@
 
         __Minimum server version__: 5.29
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: UpdateCloudCustomerAddress
       requestBody:
         content:
           application/json:
@@ -220,6 +226,7 @@
 
         __Minimum server version__: 5.28
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetCloudSubscription
       responses:
         "200":
           description: Cloud subscription returned successfully
@@ -249,6 +256,7 @@
 
         __Minimum server version__: 5.30
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetCloudSubscriptionInvoices
       responses:
         "200":
           description: Subscription invoices returned successfully
@@ -280,6 +288,7 @@
 
         __Minimum server version__: 5.30
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetCloudInvoicePdf
       parameters:
         - name: invoice_id
           in: path
@@ -310,6 +319,7 @@
 
         __Minimum server version__: 5.30
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: PostEndpointForCwsWebhooks
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -333,6 +343,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: GetEndpointForCloudSubscriptionStats
       responses:
         "200":
           description: Cloud subscription stats returned successfully
@@ -356,6 +367,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: TriggerAdminEmailOnInvite
       responses:
         "200":
           description: Email sent to at least one of the system administrators
@@ -379,6 +391,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
+      operationId: TriggerAdminEmailOnJoin
       responses:
         "200":
           description: Email sent to at least one of the system administrators

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -45,7 +45,7 @@
         __Minimum server version__: 5.28
         __Note:__: This is intended for internal use and is subject to change.
 
-      operationId: CreateCustomerSetupPaymentIntent
+      operationId: CreateCustomerPayment
       responses:
         "201":
           description: Payment setup intented created
@@ -76,7 +76,7 @@
         __Minimum server version__: 5.28
 
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: CompletePaymentSetupIntent
+      operationId: ConfirmCustomerPayment
       requestBody:
         content:
           multipart/form-data:
@@ -226,7 +226,7 @@
 
         __Minimum server version__: 5.28
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: GetCloudSubscription
+      operationId: GetSubscription
       responses:
         "200":
           description: Cloud subscription returned successfully
@@ -256,7 +256,7 @@
 
         __Minimum server version__: 5.30
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: GetCloudSubscriptionInvoices
+      operationId: GetInvoicesForSubscription
       responses:
         "200":
           description: Subscription invoices returned successfully
@@ -288,7 +288,7 @@
 
         __Minimum server version__: 5.30
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: GetCloudInvoicePdf
+      operationId: GetInvoiceForSubscriptionAsPdf
       parameters:
         - name: invoice_id
           in: path
@@ -343,7 +343,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: GetEndpointForCloudSubscriptionStats
+      operationId: GetSubscriptionStats
       responses:
         "200":
           description: Cloud subscription stats returned successfully
@@ -367,7 +367,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: TriggerAdminEmailOnInvite
+      operationId: SendAdminUpgradeRequestEmail
       responses:
         "200":
           description: Email sent to at least one of the system administrators
@@ -391,7 +391,7 @@
 
         __Minimum server version__: 5.34
         __Note:__ This is intended for internal use and is subject to change.
-      operationId: TriggerAdminEmailOnJoin
+      operationId: SendAdminUpgradeRequestEmailOnJoin
       responses:
         "200":
           description: Email sent to at least one of the system administrators

--- a/v4/source/cluster.yaml
+++ b/v4/source/cluster.yaml
@@ -10,6 +10,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetClusterStatus
       responses:
         "200":
           description: Cluster status retrieval successful

--- a/v4/source/commands.yaml
+++ b/v4/source/commands.yaml
@@ -7,6 +7,7 @@
         Create a command for a team.
         ##### Permissions
         `manage_slash_commands` for the team the command is in.
+      operationId: CreateCommand
       requestBody:
         content:
           application/json:
@@ -77,6 +78,7 @@
         List commands for a team.
         ##### Permissions
         `manage_slash_commands` if need list custom commands.
+      operationId: ListCommands
       parameters:
         - name: team_id
           in: query
@@ -134,6 +136,7 @@
         List autocomplete commands in the team.
         ##### Permissions
         `view_team` for the team.
+      operationId: ListAutocompleteCommands
       parameters:
         - name: team_id
           in: path
@@ -176,6 +179,7 @@
         ##### Permissions
         `view_team` for the team.
         __Minimum server version__: 5.24
+      operationId: ListCommandsAutocompleteSuggestions
       parameters:
         - name: team_id
           in: path
@@ -230,6 +234,7 @@
 
 
         __Minimum server version__: 5.22
+      operationId: GetCommand
       parameters:
         - in: path
           name: command_id
@@ -270,6 +275,7 @@
         ##### Permissions
 
         Must have `manage_slash_commands` permission for the team the command is in.
+      operationId: UpdateCommand
       parameters:
         - in: path
           name: command_id
@@ -324,6 +330,7 @@
         ##### Permissions
 
         Must have `manage_slash_commands` permission for the team the command is in.
+      operationId: DeleteCommand
       parameters:
         - in: path
           name: command_id
@@ -370,6 +377,7 @@
 
 
         __Minimum server version__: 5.22
+      operationId: MoveCommand
       parameters:
         - in: path
           name: command_id
@@ -423,6 +431,7 @@
         ##### Permissions
 
         Must have `manage_slash_commands` permission for the team the command is in.
+      operationId: RegenCommandToken
       parameters:
         - in: path
           name: command_id
@@ -468,6 +477,7 @@
         ##### Permissions
 
         Must have `use_slash_commands` permission for the team the command is in.
+      operationId: ExecuteCommand
       requestBody:
         content:
           application/json:

--- a/v4/source/commands.yaml
+++ b/v4/source/commands.yaml
@@ -179,7 +179,7 @@
         ##### Permissions
         `view_team` for the team.
         __Minimum server version__: 5.24
-      operationId: ListCommandsAutocompleteSuggestions
+      operationId: ListCommandAutocompleteSuggestions
       parameters:
         - name: team_id
           in: path
@@ -234,7 +234,7 @@
 
 
         __Minimum server version__: 5.22
-      operationId: GetCommand
+      operationId: GetCommandById
       parameters:
         - in: path
           name: command_id

--- a/v4/source/compliance.yaml
+++ b/v4/source/compliance.yaml
@@ -7,6 +7,7 @@
         Create and save a compliance report.
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: CreateReport
       responses:
         "201":
           description: Compliance report creation successful
@@ -33,6 +34,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetReports
       parameters:
         - name: page
           in: query
@@ -72,6 +74,7 @@
         Get a compliance reports previously created.
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: GetReport
       parameters:
         - name: report_id
           in: path
@@ -103,6 +106,7 @@
         Download the full contents of a report as a file.
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: DownloadReport
       parameters:
         - name: report_id
           in: path

--- a/v4/source/compliance.yaml
+++ b/v4/source/compliance.yaml
@@ -7,7 +7,7 @@
         Create and save a compliance report.
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: CreateReport
+      operationId: CreateComplianceReport
       responses:
         "201":
           description: Compliance report creation successful
@@ -34,7 +34,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: GetReports
+      operationId: GetComplianceReports
       parameters:
         - name: page
           in: query
@@ -74,7 +74,7 @@
         Get a compliance reports previously created.
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: GetReport
+      operationId: GetComplianceReport
       parameters:
         - name: report_id
           in: path
@@ -106,7 +106,7 @@
         Download the full contents of a report as a file.
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: DownloadReport
+      operationId: DownloadComplianceReport
       parameters:
         - name: report_id
           in: path

--- a/v4/source/dataretention.yaml
+++ b/v4/source/dataretention.yaml
@@ -15,6 +15,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetDataRetentionPolicy
       responses:
         "200":
           description: Global data retention policy details retrieved successfully.
@@ -46,6 +47,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetDataRetentionPoliciesCount
       responses:
         "200":
           description: Number of retention policies retrieved successfully.
@@ -81,6 +83,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetDataRetentionPolicies
       parameters:
         - name: page
           in: query
@@ -126,6 +129,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: CreateDataRetentionPolicy
       requestBody:
         required: true
         content:
@@ -162,6 +166,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetDataRetentionPolicyByID
       parameters:
       - name: policy_id
         in: path
@@ -199,6 +204,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: PatchDataRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -241,6 +247,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: DeleteDataRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -278,6 +285,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetTeamsForRetentionPolicy
       parameters:
         - name: policy_id
           in: path
@@ -328,6 +336,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: AddTeamsToRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -373,6 +382,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: RemoveTeamsFromRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -419,6 +429,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: SearchTeamsForRetentionPolicy
       parameters:
         - name: policy_id
           in: path
@@ -468,6 +479,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetChannelsForRetentionPolicy
       parameters:
         - name: policy_id
           in: path
@@ -516,6 +528,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: AddChannelsToRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -561,6 +574,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: RemoveChannelsFromRetentionPolicy
       parameters:
       - name: policy_id
         in: path
@@ -607,6 +621,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: SearchChannelsForRetentionPolicy
       parameters:
         - name: policy_id
           in: path

--- a/v4/source/elasticsearch.yaml
+++ b/v4/source/elasticsearch.yaml
@@ -17,7 +17,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: TestElasticsearchConfiguration
+      operationId: TestElasticsearch
       responses:
         "200":
           description: Elasticsearch test successful

--- a/v4/source/elasticsearch.yaml
+++ b/v4/source/elasticsearch.yaml
@@ -17,6 +17,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: TestElasticsearchConfiguration
       responses:
         "200":
           description: Elasticsearch test successful
@@ -46,6 +47,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: PurgeElasticsearchIndexes
       responses:
         "200":
           description: Indexes purged successfully.

--- a/v4/source/emoji.yaml
+++ b/v4/source/emoji.yaml
@@ -7,7 +7,7 @@
         Create a custom emoji for the team.
         ##### Permissions
         Must be authenticated.
-      operationId: CreateCustomEmoji
+      operationId: CreateEmoji
       requestBody:
         content:
           multipart/form-data:
@@ -54,7 +54,7 @@
         ##### Permissions
 
         Must be authenticated.
-      operationId: GetCustomEmojis
+      operationId: GetEmojiList
       parameters:
         - name: page
           in: query
@@ -99,7 +99,7 @@
         Get some metadata for a custom emoji.
         ##### Permissions
         Must be authenticated.
-      operationId: GetCustomEmoji
+      operationId: GetEmoji
       parameters:
         - name: emoji_id
           in: path
@@ -132,7 +132,7 @@
         ##### Permissions
 
         Must have the `manage_team` or `manage_system` permissions or be the user who created the emoji.
-      operationId: DeleteCustomEmoji
+      operationId: DeleteEmoji
       parameters:
         - name: emoji_id
           in: path
@@ -166,7 +166,7 @@
         Must be authenticated.
 
         __Minimum server version__: 4.7
-      operationId: GetCustomEmojiByName
+      operationId: GetEmojiByName
       parameters:
         - name: emoji_name
           in: path
@@ -198,7 +198,7 @@
         Get the image for a custom emoji.
         ##### Permissions
         Must be authenticated.
-      operationId: GetCustomEmojiImage
+      operationId: GetEmojiImage
       parameters:
         - name: emoji_id
           in: path
@@ -234,7 +234,7 @@
 
 
         __Minimum server version__: 4.7
-      operationId: SearchCustomEmoji
+      operationId: SearchEmoji
       requestBody:
         content:
           application/json:
@@ -283,7 +283,7 @@
 
 
         __Minimum server version__: 4.7
-      operationId: AutocompleteCustomEmoji
+      operationId: AutocompleteEmoji
       parameters:
         - name: name
           in: query

--- a/v4/source/emoji.yaml
+++ b/v4/source/emoji.yaml
@@ -7,6 +7,7 @@
         Create a custom emoji for the team.
         ##### Permissions
         Must be authenticated.
+      operationId: CreateCustomEmoji
       requestBody:
         content:
           multipart/form-data:
@@ -53,6 +54,7 @@
         ##### Permissions
 
         Must be authenticated.
+      operationId: GetCustomEmojis
       parameters:
         - name: page
           in: query
@@ -97,6 +99,7 @@
         Get some metadata for a custom emoji.
         ##### Permissions
         Must be authenticated.
+      operationId: GetCustomEmoji
       parameters:
         - name: emoji_id
           in: path
@@ -129,6 +132,7 @@
         ##### Permissions
 
         Must have the `manage_team` or `manage_system` permissions or be the user who created the emoji.
+      operationId: DeleteCustomEmoji
       parameters:
         - name: emoji_id
           in: path
@@ -162,6 +166,7 @@
         Must be authenticated.
 
         __Minimum server version__: 4.7
+      operationId: GetCustomEmojiByName
       parameters:
         - name: emoji_name
           in: path
@@ -193,6 +198,7 @@
         Get the image for a custom emoji.
         ##### Permissions
         Must be authenticated.
+      operationId: GetCustomEmojiImage
       parameters:
         - name: emoji_id
           in: path
@@ -228,6 +234,7 @@
 
 
         __Minimum server version__: 4.7
+      operationId: SearchCustomEmoji
       requestBody:
         content:
           application/json:
@@ -276,6 +283,7 @@
 
 
         __Minimum server version__: 4.7
+      operationId: AutocompleteCustomEmoji
       parameters:
         - name: name
           in: query

--- a/v4/source/exports.yaml
+++ b/v4/source/exports.yaml
@@ -11,6 +11,7 @@
         ##### Permissions
 
         Must have `manage_system` permissions.
+      operationId: ListExports
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -46,6 +47,7 @@
         ##### Permissions
 
         Must have `manage_system` permissions.
+      operationId: DownloadExport
       parameters:
         - name: export_name
           in: path
@@ -97,6 +99,7 @@
         ##### Permissions
 
         Must have `manage_system` permissions.
+      operationId: DeleteExport
       parameters:
         - name: export_name
           in: path

--- a/v4/source/files.yaml
+++ b/v4/source/files.yaml
@@ -251,7 +251,7 @@
         ##### Permissions
 
         Must have `read_channel` permission or be uploader of the file.
-      operationId: GetPublicFileLink
+      operationId: GetFileLink
       parameters:
         - name: file_id
           in: path
@@ -299,7 +299,7 @@
         Gets a file's info.
         ##### Permissions
         Must have `read_channel` permission or be uploader of the file.
-      operationId: GetMetadataForFile
+      operationId: GetFileInfo
       parameters:
         - name: file_id
           in: path
@@ -343,7 +343,7 @@
       description: |
         ##### Permissions
         No permissions required.
-      operationId: GetPublicFile
+      operationId: GetFilePublic
       parameters:
         - name: file_id
           in: path
@@ -386,7 +386,7 @@
         ##### Permissions
 
         Must be authenticated and have the `view_team` permission.
-      operationId: SearchFilesInTeam
+      operationId: SearchFiles
       parameters:
         - name: team_id
           in: path

--- a/v4/source/files.yaml
+++ b/v4/source/files.yaml
@@ -22,6 +22,7 @@
         ##### Permissions
 
         Must have `upload_file` permission.
+      operationId: UploadFile
       parameters:
         - name: channel_id
           in: query
@@ -130,6 +131,7 @@
         Gets a file that has been uploaded previously.
         ##### Permissions
         Must have `read_channel` permission or be uploader of the file.
+      operationId: GetFile
       parameters:
         - name: file_id
           in: path
@@ -168,6 +170,7 @@
         Gets a file's thumbnail.
         ##### Permissions
         Must have `read_channel` permission or be uploader of the file.
+      operationId: GetFileThumbnail
       parameters:
         - name: file_id
           in: path
@@ -206,6 +209,7 @@
         Gets a file's preview.
         ##### Permissions
         Must have `read_channel` permission or be uploader of the file.
+      operationId: GetFilePreview
       parameters:
         - name: file_id
           in: path
@@ -247,6 +251,7 @@
         ##### Permissions
 
         Must have `read_channel` permission or be uploader of the file.
+      operationId: GetPublicFileLink
       parameters:
         - name: file_id
           in: path
@@ -294,6 +299,7 @@
         Gets a file's info.
         ##### Permissions
         Must have `read_channel` permission or be uploader of the file.
+      operationId: GetMetadataForFile
       parameters:
         - name: file_id
           in: path
@@ -337,6 +343,7 @@
       description: |
         ##### Permissions
         No permissions required.
+      operationId: GetPublicFile
       parameters:
         - name: file_id
           in: path
@@ -379,6 +386,7 @@
         ##### Permissions
 
         Must be authenticated and have the `view_team` permission.
+      operationId: SearchFilesInTeam
       parameters:
         - name: team_id
           in: path

--- a/v4/source/groups.yaml
+++ b/v4/source/groups.yaml
@@ -18,6 +18,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: GetGroups
       parameters:
         - name: page
           in: query
@@ -97,6 +98,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroup
       parameters:
         - name: group_id
           in: path
@@ -137,6 +139,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: PatchGroup
       parameters:
         - name: group_id
           in: path
@@ -184,6 +187,7 @@
         Must have `manage_team` permission.
 
         __Minimum server version__: 5.11
+      operationId: LinkTeamToGroup
       parameters:
         - name: group_id
           in: path
@@ -222,6 +226,7 @@
         Must have `manage_team` permission.
 
         __Minimum server version__: 5.11
+      operationId: DeleteLinkFromTeamToGroup
       parameters:
         - name: group_id
           in: path
@@ -266,6 +271,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: LinkChannelToGroup
       parameters:
         - name: group_id
           in: path
@@ -309,6 +315,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: DeleteLinkFromChannelToGroup
       parameters:
         - name: group_id
           in: path
@@ -348,6 +355,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroupsyncableFromTeamId
       parameters:
         - name: group_id
           in: path
@@ -389,6 +397,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroupsyncableFromChannelId
       parameters:
         - name: group_id
           in: path
@@ -430,6 +439,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroupTeams
       parameters:
         - name: group_id
           in: path
@@ -467,6 +477,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroupChannels
       parameters:
         - name: group_id
           in: path
@@ -511,6 +522,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: PatchGroupsyncableAssociatedToTeam
       parameters:
         - name: group_id
           in: path
@@ -568,6 +580,7 @@
 
 
         __Minimum server version__: 5.11
+      operationId: PatchGroupsyncableAssociatedToChannel
       parameters:
         - name: group_id
           in: path
@@ -618,6 +631,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetGroupUsers
       parameters:
         - name: group_id
           in: path
@@ -673,6 +687,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.26
+      operationId: GetGroupStats
       parameters:
         - name: group_id
           in: path
@@ -714,6 +729,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetChannelGroups
       parameters:
         - name: channel_id
           in: path
@@ -767,6 +783,7 @@
         Retrieve the list of groups associated with a given team.
 
         __Minimum server version__: 5.11
+      operationId: GetTeamGroups
       parameters:
         - name: team_id
           in: path
@@ -823,6 +840,7 @@
           Must have `manage_system` permission or can access only for current user
 
           __Minimum server version__: 5.11
+        operationId: GetTeamGroupsByChannels
         parameters:
           - name: team_id
             in: path
@@ -876,6 +894,7 @@
         Retrieve the list of groups associated to the user
 
         __Minimum server version__: 5.24
+      operationId: GetGroupsForUserid
       parameters:
         - name: user_id
           in: path

--- a/v4/source/groups.yaml
+++ b/v4/source/groups.yaml
@@ -187,7 +187,7 @@
         Must have `manage_team` permission.
 
         __Minimum server version__: 5.11
-      operationId: LinkTeamToGroup
+      operationId: LinkGroupSyncableForTeam
       parameters:
         - name: group_id
           in: path
@@ -226,7 +226,7 @@
         Must have `manage_team` permission.
 
         __Minimum server version__: 5.11
-      operationId: DeleteLinkFromTeamToGroup
+      operationId: UnlinkGroupSyncableForTeam
       parameters:
         - name: group_id
           in: path
@@ -271,7 +271,7 @@
 
 
         __Minimum server version__: 5.11
-      operationId: LinkChannelToGroup
+      operationId: LinkGroupSyncableForChannel
       parameters:
         - name: group_id
           in: path
@@ -315,7 +315,7 @@
 
 
         __Minimum server version__: 5.11
-      operationId: DeleteLinkFromChannelToGroup
+      operationId: UnlinkGroupSyncableForChannel
       parameters:
         - name: group_id
           in: path
@@ -355,7 +355,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: GetGroupsyncableFromTeamId
+      operationId: GetGroupSyncableForTeamId
       parameters:
         - name: group_id
           in: path
@@ -397,7 +397,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: GetGroupsyncableFromChannelId
+      operationId: GetGroupSyncableForChannelId
       parameters:
         - name: group_id
           in: path
@@ -439,7 +439,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: GetGroupTeams
+      operationId: GetGroupSyncablesTeams
       parameters:
         - name: group_id
           in: path
@@ -477,7 +477,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: GetGroupChannels
+      operationId: GetGroupSyncablesChannels
       parameters:
         - name: group_id
           in: path
@@ -522,7 +522,7 @@
 
 
         __Minimum server version__: 5.11
-      operationId: PatchGroupsyncableAssociatedToTeam
+      operationId: PatchGroupSyncableForTeam
       parameters:
         - name: group_id
           in: path
@@ -580,7 +580,7 @@
 
 
         __Minimum server version__: 5.11
-      operationId: PatchGroupsyncableAssociatedToChannel
+      operationId: PatchGroupSyncableForChannel
       parameters:
         - name: group_id
           in: path
@@ -729,7 +729,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: GetChannelGroups
+      operationId: GetGroupsByChannel
       parameters:
         - name: channel_id
           in: path
@@ -783,7 +783,7 @@
         Retrieve the list of groups associated with a given team.
 
         __Minimum server version__: 5.11
-      operationId: GetTeamGroups
+      operationId: GetGroupsByTeam
       parameters:
         - name: team_id
           in: path
@@ -840,7 +840,7 @@
           Must have `manage_system` permission or can access only for current user
 
           __Minimum server version__: 5.11
-        operationId: GetTeamGroupsByChannels
+        operationId: GetGroupsAssociatedToChannelsByTeam
         parameters:
           - name: team_id
             in: path
@@ -894,7 +894,7 @@
         Retrieve the list of groups associated to the user
 
         __Minimum server version__: 5.24
-      operationId: GetGroupsForUserid
+      operationId: GetGroupsByUserId
       parameters:
         - name: user_id
           in: path

--- a/v4/source/imports.yaml
+++ b/v4/source/imports.yaml
@@ -12,6 +12,7 @@
         ##### Permissions
 
         Must have `manage_system` permissions.
+      operationId: ListImports
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -12,6 +12,7 @@
         ##### Permissions
 
         Must have `manage_jobs` permission.
+      operationId: GetJobs
       parameters:
         - name: page
           in: query
@@ -49,6 +50,7 @@
         __Minimum server version: 4.1__
         ##### Permissions
         Must have `manage_jobs` permission.
+      operationId: CreateNewJob
       requestBody:
         content:
           application/json:
@@ -89,6 +91,7 @@
         __Minimum server version: 4.1__
         ##### Permissions
         Must have `manage_jobs` permission.
+      operationId: GetJob
       parameters:
         - name: job_id
           in: path
@@ -121,6 +124,7 @@
         __Minimum server version: 5.28__
         ##### Permissions
         Must have `manage_jobs` permission.
+      operationId: DownloadJobResults
       parameters:
         - name: job_id
           in: path
@@ -147,6 +151,7 @@
         __Minimum server version: 4.1__
         ##### Permissions
         Must have `manage_jobs` permission.
+      operationId: CancelJob
       parameters:
         - name: job_id
           in: path
@@ -183,6 +188,7 @@
         ##### Permissions
 
         Must have `manage_jobs` permission.
+      operationId: GetJobsOfGivenType
       parameters:
         - name: type
           in: path

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -50,7 +50,7 @@
         __Minimum server version: 4.1__
         ##### Permissions
         Must have `manage_jobs` permission.
-      operationId: CreateNewJob
+      operationId: CreateJob
       requestBody:
         content:
           application/json:
@@ -124,7 +124,7 @@
         __Minimum server version: 5.28__
         ##### Permissions
         Must have `manage_jobs` permission.
-      operationId: DownloadJobResults
+      operationId: DownloadJob
       parameters:
         - name: job_id
           in: path
@@ -188,7 +188,7 @@
         ##### Permissions
 
         Must have `manage_jobs` permission.
-      operationId: GetJobsOfGivenType
+      operationId: GetJobsByType
       parameters:
         - name: type
           in: path

--- a/v4/source/ldap.yaml
+++ b/v4/source/ldap.yaml
@@ -10,7 +10,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: SyncWithLdap
+      operationId: SyncLdap
       responses:
         "200":
           description: LDAP sync successful
@@ -32,7 +32,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: TestLdapConfiguration
+      operationId: TestLdap
       responses:
         "200":
           description: LDAP test successful
@@ -133,7 +133,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
-      operationId: DeleteLinkForLdapGroup
+      operationId: UnlinkLdapGroup
       parameters:
         - name: remote_id
           in: path
@@ -247,7 +247,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: RemoveLdapPublicCertificate
+      operationId: DeleteLdapPublicCertificate
       responses:
         "200":
           description: LDAP certificate delete successful
@@ -273,7 +273,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: UploadLdapPrivateKey
+      operationId: UploadLdapPrivateCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -311,7 +311,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: RemoveLdapPrivateKey
+      operationId: DeleteLdapPrivateCertificate
       responses:
         "200":
           description: LDAP certificate delete successful

--- a/v4/source/ldap.yaml
+++ b/v4/source/ldap.yaml
@@ -10,6 +10,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: SyncWithLdap
       responses:
         "200":
           description: LDAP sync successful
@@ -31,6 +32,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: TestLdapConfiguration
       responses:
         "200":
           description: LDAP test successful
@@ -53,6 +55,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: GetLdapGroups
       parameters:
         - name: q
           in: query
@@ -99,6 +102,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: LinkLdapGroup
       parameters:
         - name: remote_id
           in: path
@@ -129,6 +133,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.11
+      operationId: DeleteLinkForLdapGroup
       parameters:
         - name: remote_id
           in: path
@@ -162,6 +167,7 @@
         Must have `manage_system` permission.
   
         __Minimum server version__: 5.26
+      operationId: MigrateIdLdap
       requestBody:
         content:
           application/json:
@@ -203,6 +209,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: UploadLdapPublicCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -240,6 +247,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RemoveLdapPublicCertificate
       responses:
         "200":
           description: LDAP certificate delete successful
@@ -265,6 +273,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: UploadLdapPrivateKey
       requestBody:
         content:
           multipart/form-data:
@@ -302,6 +311,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RemoveLdapPrivateKey
       responses:
         "200":
           description: LDAP certificate delete successful

--- a/v4/source/oauth.yaml
+++ b/v4/source/oauth.yaml
@@ -10,6 +10,7 @@
         ##### Permissions
 
         Must have `manage_oauth` permission.
+      operationId: RegisterOAuthApp
       requestBody:
         content:
           application/json:
@@ -68,6 +69,7 @@
         ##### Permissions
 
         With `manage_oauth` permission, the apps registered by the logged in user are returned. With `manage_system_wide_oauth` permission, all apps regardless of creator are returned.
+      operationId: GetOAuthApps
       parameters:
         - name: page
           in: query
@@ -109,6 +111,7 @@
         ##### Permissions
 
         If app creator, must have `mange_oauth` permission otherwise `manage_system_wide_oauth` permission is required.
+      operationId: GetOAuthApp
       parameters:
         - name: app_id
           in: path
@@ -143,6 +146,7 @@
         ##### Permissions
 
         If app creator, must have `mange_oauth` permission otherwise `manage_system_wide_oauth` permission is required.
+      operationId: UpdateOAuthApp
       parameters:
         - name: app_id
           in: path
@@ -235,6 +239,7 @@
         ##### Permissions
 
         If app creator, must have `mange_oauth` permission otherwise `manage_system_wide_oauth` permission is required.
+      operationId: DeleteOAuthApp
       parameters:
         - name: app_id
           in: path
@@ -271,6 +276,7 @@
         ##### Permissions
 
         If app creator, must have `mange_oauth` permission otherwise `manage_system_wide_oauth` permission is required.
+      operationId: RegenerateOAuthAppSecret
       parameters:
         - name: app_id
           in: path
@@ -307,6 +313,7 @@
         ##### Permissions
 
         Must be authenticated.
+      operationId: GetInfoOnOAuthApp
       parameters:
         - name: app_id
           in: path
@@ -341,6 +348,7 @@
         ##### Permissions
 
         Must be authenticated as the user or have `edit_other_users` permission.
+      operationId: GetAuthorizedOAuthApps
       parameters:
         - name: user_id
           in: path

--- a/v4/source/oauth.yaml
+++ b/v4/source/oauth.yaml
@@ -10,7 +10,7 @@
         ##### Permissions
 
         Must have `manage_oauth` permission.
-      operationId: RegisterOAuthApp
+      operationId: CreateOAuthApp
       requestBody:
         content:
           application/json:
@@ -313,7 +313,7 @@
         ##### Permissions
 
         Must be authenticated.
-      operationId: GetInfoOnOAuthApp
+      operationId: GetOAuthAppInfo
       parameters:
         - name: app_id
           in: path
@@ -348,7 +348,7 @@
         ##### Permissions
 
         Must be authenticated as the user or have `edit_other_users` permission.
-      operationId: GetAuthorizedOAuthApps
+      operationId: GetAuthorizedOAuthAppsForUser
       parameters:
         - name: user_id
           in: path

--- a/v4/source/opengraph.yaml
+++ b/v4/source/opengraph.yaml
@@ -14,6 +14,7 @@
         ##### Permissions
 
         No permission required but must be logged in.
+      operationId: GetOpenGraphMetadataForUrl
       requestBody:
         content:
           application/json:

--- a/v4/source/opengraph.yaml
+++ b/v4/source/opengraph.yaml
@@ -14,7 +14,7 @@
         ##### Permissions
 
         No permission required but must be logged in.
-      operationId: GetOpenGraphMetadataForUrl
+      operationId: OpenGraph
       requestBody:
         content:
           application/json:

--- a/v4/source/permissions.yaml
+++ b/v4/source/permissions.yaml
@@ -9,6 +9,7 @@
 
 
         __Minimum server version__: 5.35
+      operationId: GetAncillaryPermissions
       parameters:
         - name: subsection_permissions
           in: query

--- a/v4/source/plugins.yaml
+++ b/v4/source/plugins.yaml
@@ -573,6 +573,7 @@
         __Minimum server version: 5.33__
         ##### Permissions
         Must have `manage_system` permissions.
+      operationId: GetMarketplaceVisitedByAdmin
       responses:
         "200":
           description: Retrieves the system-level status
@@ -593,6 +594,7 @@
         __Minimum server version: 5.33__
         ##### Permissions
         Must have `manage_system` permissions.
+      operationId: UpdateMarketplaceVisitedByAdmin
       requestBody:
         content:
           application/json:

--- a/v4/source/plugins.yaml
+++ b/v4/source/plugins.yaml
@@ -15,6 +15,7 @@
 
 
         __Minimum server version__: 4.4
+      operationId: UploadPlugin
       requestBody:
         content:
           multipart/form-data:
@@ -95,6 +96,7 @@
 
 
         __Minimum server version__: 4.4
+      operationId: GetPlugins
       responses:
         "200":
           description: Plugins retrieval successful
@@ -144,6 +146,7 @@
 
 
         __Minimum server version__: 5.14
+      operationId: InstallPluginFromUrl
       parameters:
         - name: plugin_download_url
           in: query
@@ -204,6 +207,7 @@
 
 
         __Minimum server version__: 4.4
+      operationId: RemovePlugin
       parameters:
         - name: plugin_id
           in: path
@@ -254,6 +258,7 @@
 
 
         __Minimum server version__: 4.4
+      operationId: EnablePlugin
       parameters:
         - name: plugin_id
           in: path
@@ -304,6 +309,7 @@
 
 
         __Minimum server version__: 4.4
+      operationId: DisablePlugin
       parameters:
         - name: plugin_id
           in: path
@@ -350,6 +356,7 @@
         No permissions required.
 
         __Minimum server version__: 4.4
+      operationId: GetWebappPlugins
       responses:
         "200":
           description: Plugin deactivated successfully
@@ -387,6 +394,7 @@
         No permissions required.
 
         __Minimum server version__: 4.4
+      operationId: GetPluginStatuses
       responses:
         "200":
           description: Plugin status retreived successfully
@@ -424,6 +432,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.16
+      operationId: InstallMarketplacePlugin
       requestBody:
         content:
           application/json:
@@ -488,6 +497,7 @@
 
 
         __Minimum server version__: 5.16
+      operationId: GetMarketplacePlugins
       parameters:
         - name: page
           in: query

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -10,6 +10,7 @@
         ##### Permissions
 
         Must have `create_post` permission for the channel the post is being created in.
+      operationId: CreatePost
       parameters:
         - name: set_online
           in: query
@@ -71,6 +72,7 @@
         ##### Permissions
 
         Must have `create_post_ephemeral` permission (currently only given to system admin)
+      operationId: CreatePostEphemeral
       requestBody:
         content:
           application/json:
@@ -137,6 +139,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels` permission for the team.
+      operationId: GetPost
       parameters:
         - name: post_id
           in: path
@@ -168,6 +171,7 @@
         ##### Permissions
 
         Must be logged in as the user or have `delete_others_posts` permission.
+      operationId: DeletePost
       parameters:
         - name: post_id
           in: path
@@ -199,6 +203,7 @@
         ##### Permissions
 
         Must have `edit_post` permission for the channel the post is in.
+      operationId: UpdatePost
       parameters:
         - name: post_id
           in: path
@@ -260,6 +265,7 @@
 
 
         __Minimum server version__: 5.18
+      operationId: MarkAsUnreadFromPost
       parameters:
         - name: user_id
           in: path
@@ -301,6 +307,7 @@
         ##### Permissions
 
         Must have the `edit_post` permission.
+      operationId: PatchPost
       parameters:
         - name: post_id
           in: path
@@ -357,6 +364,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels` permission for the team.
+      operationId: GetThread
       parameters:
         - name: post_id
           in: path
@@ -389,6 +397,7 @@
         ##### Permissions
 
         Must be user or have `manage_system` permission.
+      operationId: GetFlaggedPosts
       parameters:
         - name: user_id
           in: path
@@ -445,6 +454,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel the post is in.
+      operationId: GetFileInfoForPost
       parameters:
         - name: post_id
           in: path
@@ -485,6 +495,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel.
+      operationId: GetPostsForChannel
       parameters:
         - name: channel_id
           in: path
@@ -548,6 +559,7 @@
         Must be logged in as the user or have `edit_other_users` permission, and must have `read_channel` permission for the channel.
 
         __Minimum server version__: 5.14
+      operationId: GetPostsAroundOldestUnread
       parameters:
         - name: user_id
           in: path
@@ -601,6 +613,7 @@
         Search posts in the team and from the provided terms string.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
+      operationId: SearchForTeamPosts
       parameters:
         - name: team_id
           in: path
@@ -670,6 +683,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
+      operationId: PinPostToChannel
       parameters:
         - name: post_id
           in: path
@@ -702,6 +716,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
+      operationId: UnpinPostToChannel
       parameters:
         - name: post_id
           in: path
@@ -734,6 +749,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
+      operationId: PerformPostAction
       parameters:
         - name: post_id
           in: path

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -265,7 +265,7 @@
 
 
         __Minimum server version__: 5.18
-      operationId: MarkAsUnreadFromPost
+      operationId: SetPostUnread
       parameters:
         - name: user_id
           in: path
@@ -364,7 +364,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels` permission for the team.
-      operationId: GetThread
+      operationId: GetPostThread
       parameters:
         - name: post_id
           in: path
@@ -397,7 +397,7 @@
         ##### Permissions
 
         Must be user or have `manage_system` permission.
-      operationId: GetFlaggedPosts
+      operationId: GetFlaggedPostsForUser
       parameters:
         - name: user_id
           in: path
@@ -454,7 +454,7 @@
         ##### Permissions
 
         Must have `read_channel` permission for the channel the post is in.
-      operationId: GetFileInfoForPost
+      operationId: GetFileInfosForPost
       parameters:
         - name: post_id
           in: path
@@ -559,7 +559,7 @@
         Must be logged in as the user or have `edit_other_users` permission, and must have `read_channel` permission for the channel.
 
         __Minimum server version__: 5.14
-      operationId: GetPostsAroundOldestUnread
+      operationId: GetPostsAroundLastUnread
       parameters:
         - name: user_id
           in: path
@@ -613,7 +613,7 @@
         Search posts in the team and from the provided terms string.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
-      operationId: SearchForTeamPosts
+      operationId: SearchPosts
       parameters:
         - name: team_id
           in: path
@@ -683,7 +683,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
-      operationId: PinPostToChannel
+      operationId: PinPost
       parameters:
         - name: post_id
           in: path
@@ -716,7 +716,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
-      operationId: UnpinPostToChannel
+      operationId: UnpinPost
       parameters:
         - name: post_id
           in: path
@@ -749,7 +749,7 @@
         ##### Permissions
 
         Must be authenticated and have the `read_channel` permission to the channel the post is in.
-      operationId: PerformPostAction
+      operationId: DoPostAction
       parameters:
         - name: post_id
           in: path

--- a/v4/source/preferences.yaml
+++ b/v4/source/preferences.yaml
@@ -9,6 +9,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: GetUserPreferences
       parameters:
         - name: user_id
           in: path
@@ -41,6 +42,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: SaveUserPreferences
       parameters:
         - name: user_id
           in: path
@@ -83,6 +85,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: DeleteUserPreferences
       parameters:
         - name: user_id
           in: path
@@ -123,6 +126,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: GetUserPreferencesByCategory
       parameters:
         - name: user_id
           in: path
@@ -163,6 +167,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: GetSpecificUserPreference
       parameters:
         - name: user_id
           in: path

--- a/v4/source/preferences.yaml
+++ b/v4/source/preferences.yaml
@@ -9,7 +9,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: GetUserPreferences
+      operationId: GetPreferences
       parameters:
         - name: user_id
           in: path
@@ -42,7 +42,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: SaveUserPreferences
+      operationId: UpdatePreferences
       parameters:
         - name: user_id
           in: path
@@ -85,7 +85,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: DeleteUserPreferences
+      operationId: DeletePreferences
       parameters:
         - name: user_id
           in: path
@@ -126,7 +126,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: GetUserPreferencesByCategory
+      operationId: GetPreferencesByCategory
       parameters:
         - name: user_id
           in: path
@@ -167,7 +167,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: GetSpecificUserPreference
+      operationId: GetPreferencesByCategoryByName
       parameters:
         - name: user_id
           in: path

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -7,6 +7,7 @@
         Create a reaction.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
+      operationId: CreateReaction
       requestBody:
         content:
           application/json:
@@ -35,6 +36,7 @@
         Get a list of reactions made by all users to a given post.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
+      operationId: GetReactionsToPost
       parameters:
         - name: post_id
           in: path
@@ -66,6 +68,7 @@
         Deletes a reaction made by a user from the given post.
         ##### Permissions
         Must be user or have `manage_system` permission.
+      operationId: RemoveReactionFromPost
       parameters:
         - name: user_id
           in: path
@@ -109,6 +112,7 @@
         Must have `read_channel` permission for the channel the post is in.
 
         __Minimum server version__: 5.8
+      operationId: GetReactionsForPosts
       requestBody:
         content:
           application/json:

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -7,7 +7,7 @@
         Create a reaction.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
-      operationId: CreateReaction
+      operationId: SaveReaction
       requestBody:
         content:
           application/json:
@@ -36,7 +36,7 @@
         Get a list of reactions made by all users to a given post.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
-      operationId: GetReactionsToPost
+      operationId: GetReactions
       parameters:
         - name: post_id
           in: path
@@ -68,7 +68,7 @@
         Deletes a reaction made by a user from the given post.
         ##### Permissions
         Must be user or have `manage_system` permission.
-      operationId: RemoveReactionFromPost
+      operationId: DeleteReaction
       parameters:
         - name: user_id
           in: path
@@ -112,7 +112,7 @@
         Must have `read_channel` permission for the channel the post is in.
 
         __Minimum server version__: 5.8
-      operationId: GetReactionsForPosts
+      operationId: GetBulkReactions
       requestBody:
         content:
           application/json:

--- a/v4/source/roles.yaml
+++ b/v4/source/roles.yaml
@@ -10,6 +10,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 4.9
+      operationId: GetRole
       parameters:
         - name: role_id
           in: path
@@ -48,6 +49,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 4.9
+      operationId: GetRoleByName
       parameters:
         - name: role_name
           in: path
@@ -91,6 +93,7 @@
 
 
         __Minimum server version__: 4.9
+      operationId: PatchRole
       parameters:
         - name: role_id
           in: path
@@ -138,6 +141,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 4.9
+      operationId: GetRolesByName
       requestBody:
         content:
           application/json:

--- a/v4/source/roles.yaml
+++ b/v4/source/roles.yaml
@@ -141,7 +141,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 4.9
-      operationId: GetRolesByName
+      operationId: GetRolesByNames
       requestBody:
         content:
           application/json:

--- a/v4/source/saml.yaml
+++ b/v4/source/saml.yaml
@@ -7,7 +7,7 @@
         Get SAML metadata from the server. SAML must be configured properly.
         ##### Permissions
         No permission required.
-      operationId: GetMetadata
+      operationId: GetSamlMetadata
       responses:
         "200":
           description: SAML metadata retrieval successful
@@ -26,7 +26,7 @@
         Get SAML metadata from the Identity Provider. SAML must be configured properly.
         ##### Permissions
         No permission required.
-      operationId: GetMetadataFromIdentityProvider
+      operationId: GetSamlMetadataFromIdp
       responses:
         "200":
           description: SAML metadata retrieval successful
@@ -49,7 +49,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: UploadIdpCertificate
+      operationId: UploadSamlIdpCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -89,7 +89,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: RemoveIdpCertificate
+      operationId: DeleteSamlIdpCertificate
       responses:
         "200":
           description: SAML certificate delete successful
@@ -156,7 +156,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: RemoveSamlPublicCertificate
+      operationId: DeleteSamlPublicCertificate
       responses:
         "200":
           description: SAML certificate delete successful
@@ -183,7 +183,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: UploadSamlPrivateKey
+      operationId: UploadSamlPrivateCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -223,7 +223,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: RemoveSamlPrivateKey
+      operationId: DeleteSamlPrivateCertificate
       responses:
         "200":
           description: SAML certificate delete successful
@@ -276,6 +276,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: ResetSamlAuthDataToEmail
       requestBody:
         content:
           application/json:

--- a/v4/source/saml.yaml
+++ b/v4/source/saml.yaml
@@ -7,6 +7,7 @@
         Get SAML metadata from the server. SAML must be configured properly.
         ##### Permissions
         No permission required.
+      operationId: GetMetadata
       responses:
         "200":
           description: SAML metadata retrieval successful
@@ -25,6 +26,7 @@
         Get SAML metadata from the Identity Provider. SAML must be configured properly.
         ##### Permissions
         No permission required.
+      operationId: GetMetadataFromIdentityProvider
       responses:
         "200":
           description: SAML metadata retrieval successful
@@ -47,6 +49,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: UploadIdpCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -86,6 +89,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: RemoveIdpCertificate
       responses:
         "200":
           description: SAML certificate delete successful
@@ -112,6 +116,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: UploadSamlPublicCertificate
       requestBody:
         content:
           multipart/form-data:
@@ -151,6 +156,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: RemoveSamlPublicCertificate
       responses:
         "200":
           description: SAML certificate delete successful
@@ -177,6 +183,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: UploadSamlPrivateKey
       requestBody:
         content:
           multipart/form-data:
@@ -216,6 +223,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: RemoveSamlPrivateKey
       responses:
         "200":
           description: SAML certificate delete successful
@@ -241,6 +249,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: GetSamlCertificateStatus
       responses:
         "200":
           description: SAML certificate status retrieval successful

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -14,6 +14,7 @@
 
 
         __Minimum server version__: 5.0
+      operationId: GetSchemes
       parameters:
         - name: scope
           in: query
@@ -60,6 +61,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.0
+      operationId: CreateScheme
       requestBody:
         content:
           application/json:
@@ -107,6 +109,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.0
+      operationId: GetScheme
       parameters:
         - name: scheme_id
           in: path
@@ -146,6 +149,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.0
+      operationId: DeleteScheme
       parameters:
         - name: scheme_id
           in: path
@@ -186,6 +190,7 @@
 
 
         __Minimum server version__: 5.0
+      operationId: PatchScheme
       parameters:
         - name: scheme_id
           in: path
@@ -242,6 +247,7 @@
 
 
         __Minimum server version__: 5.0
+      operationId: GetTeamsUsingScheme
       parameters:
         - name: scheme_id
           in: path
@@ -296,6 +302,7 @@
 
 
         __Minimum server version__: 5.0
+      operationId: GetChannelsUsingScheme
       parameters:
         - name: scheme_id
           in: path

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -247,7 +247,7 @@
 
 
         __Minimum server version__: 5.0
-      operationId: GetTeamsUsingScheme
+      operationId: GetTeamsForScheme
       parameters:
         - name: scheme_id
           in: path
@@ -302,7 +302,7 @@
 
 
         __Minimum server version__: 5.0
-      operationId: GetChannelsUsingScheme
+      operationId: GetChannelsForScheme
       parameters:
         - name: scheme_id
           in: path

--- a/v4/source/service_terms.yaml
+++ b/v4/source/service_terms.yaml
@@ -9,7 +9,7 @@
         __Minimum server version__: 5.4
         ##### Permissions
         Must be authenticated.
-      operationId: GetLatestTermsOfService
+      operationId: GetTermsOfService
       responses:
         "200":
           description: Terms of service fetched successfully
@@ -31,7 +31,7 @@
         __Minimum server version__: 5.4
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: CreateNewTermsOfService
+      operationId: CreateTermsOfService
       responses:
         "200":
           description: terms of service fetched successfully

--- a/v4/source/service_terms.yaml
+++ b/v4/source/service_terms.yaml
@@ -9,6 +9,7 @@
         __Minimum server version__: 5.4
         ##### Permissions
         Must be authenticated.
+      operationId: GetLatestTermsOfService
       responses:
         "200":
           description: Terms of service fetched successfully
@@ -30,6 +31,7 @@
         __Minimum server version__: 5.4
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: CreateNewTermsOfService
       responses:
         "200":
           description: terms of service fetched successfully

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -10,6 +10,7 @@
 
         ##### Permissions
         Must be authenticated.
+      operationId: GetAllSharedChannels
       parameters:
         - name: team_id
           in: path

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -71,6 +71,7 @@
 
         ##### Permissions
         Must be authenticated and user must belong to at least one channel shared with the remote cluster.
+      operationId: GetRemoteClusterInfo
       parameters:
         - name: remote_id
           in: path

--- a/v4/source/status.yaml
+++ b/v4/source/status.yaml
@@ -7,6 +7,7 @@
         Get user status by id from the server.
         ##### Permissions
         Must be authenticated.
+      operationId: GetUserStatus
       parameters:
         - name: user_id
           in: path
@@ -37,6 +38,7 @@
         ##### Permissions
 
         Must have `edit_other_users` permission for the team.
+      operationId: UpdateUserStatus
       parameters:
         - name: user_id
           in: path
@@ -81,6 +83,7 @@
         Get a list of user statuses by id from the server.
         ##### Permissions
         Must be authenticated.
+      operationId: GetUserStatusesById
       requestBody:
         content:
           application/json:
@@ -113,6 +116,7 @@
         Updates a user's custom status by setting the value in the user's props and updates the user. Also save the given custom status to the recent custom statuses in the user's props
         ##### Permissions
         Must be logged in as the user whose custom status is being updated.
+      operationId: UpdateUserCustomStatus
       parameters:
         - name: user_id
           in: path
@@ -153,6 +157,7 @@
         Unsets a user's custom status by updating the user's props and updates the user
         ##### Permissions
         Must be logged in as the user whose custom status is being removed.
+      operationId: DeleteUserCustomStatus
       parameters:
         - name: user_id
           in: path
@@ -177,6 +182,7 @@
         Deletes a user's recent custom status by removing the specific status from the recentCustomStatuses in the user's props and updates the user.
         ##### Permissions
         Must be logged in as the user whose recent custom status is being deleted.
+      operationId: DeleteUserRecentCustomStatus
       parameters:
         - name: user_id
           in: path

--- a/v4/source/status.yaml
+++ b/v4/source/status.yaml
@@ -83,7 +83,7 @@
         Get a list of user statuses by id from the server.
         ##### Permissions
         Must be authenticated.
-      operationId: GetUserStatusesById
+      operationId: GetUsersStatusesByIds
       requestBody:
         content:
           application/json:
@@ -157,7 +157,7 @@
         Unsets a user's custom status by updating the user's props and updates the user
         ##### Permissions
         Must be logged in as the user whose custom status is being removed.
-      operationId: DeleteUserCustomStatus
+      operationId: UnsetUserCustomStatus
       parameters:
         - name: user_id
           in: path
@@ -182,7 +182,7 @@
         Deletes a user's recent custom status by removing the specific status from the recentCustomStatuses in the user's props and updates the user.
         ##### Permissions
         Must be logged in as the user whose recent custom status is being deleted.
-      operationId: DeleteUserRecentCustomStatus
+      operationId: RemoveRecentCustomStatus
       parameters:
         - name: user_id
           in: path
@@ -224,6 +224,7 @@
         Deletes a user's recent custom status by removing the specific status from the recentCustomStatuses in the user's props and updates the user.
         ##### Permissions
         Must be logged in as the user whose recent custom status is being deleted.
+      operationId: PostUserRecentCustomStatusDelete
       parameters:
         - name: user_id
           in: path

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -9,6 +9,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetSupportedTimezones
       responses:
         "200":
           description: List of timezones retrieval successful
@@ -38,6 +39,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetPingWithServerStatus
       parameters:
         - name: get_server_status
           in: query
@@ -80,6 +82,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetNotices
       parameters:
         - name: clientVersion
           in: query
@@ -139,6 +142,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: MarkNoticesViewed
       requestBody:
         content:
           application/json:
@@ -180,6 +184,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: DatabaseRecycle
       responses:
         "200":
           description: Database recycle successful
@@ -212,6 +217,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: TestEmail
       requestBody:
         description: Mattermost configuration
         required: true
@@ -265,6 +271,7 @@
 
 
         __Minimum server version__: 5.16
+      operationId: TestSiteUrl
       requestBody:
         content:
           application/json:
@@ -318,6 +325,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 4.8
+      operationId: TestS3Connection
       requestBody:
         description: Mattermost configuration
         required: true
@@ -365,6 +373,7 @@
         Retrieve the current server configuration
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: GetConfig
       responses:
         "200":
           description: Configuration retrieval successful
@@ -398,6 +407,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: UpdateConfig
       requestBody:
         description: Mattermost configuration
         required: true
@@ -440,6 +450,7 @@
         Reload the configuration file to pick up on any changes made to it.
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: ReloadConfig
       responses:
         "200":
           description: Configuration reload successful
@@ -470,6 +481,7 @@
         Get a subset of the server configuration needed by the client.
         ##### Permissions
         No permission required.
+      operationId: GetConfigClient
       parameters:
         - name: format
           in: query
@@ -514,6 +526,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetConfigEnvVariables
       responses:
         "200":
           description: Configuration retrieval successful
@@ -542,6 +555,7 @@
         Must have `manage_system` permission.
 
         __Minimum server version__: 5.20
+      operationId: PatchConfig
       requestBody:
         description: Mattermost configuration
         required: true
@@ -588,6 +602,7 @@
 
         ##### Permissions
         Must have `manage_system` permission
+      operationId: MigrateConfig
       requestBody:
         content:
           application/json:
@@ -633,6 +648,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: UploadLicenseFile
       requestBody:
         content:
           multipart/form-data:
@@ -695,6 +711,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RemoveLicenseFile
       responses:
         "200":
           description: License removal successful
@@ -713,6 +730,7 @@
         ##### Permissions
 
         No permission required but having the `manage_system` permission returns more information.
+      operationId: GetClientLicense
       parameters:
         - name: format
           in: query
@@ -750,6 +768,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_about` permission.
+      operationId: RequestLicenseRenewalLink
       responses:
         "200":
           description: License renewal link obtained
@@ -778,6 +797,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RequestTrialLicense
       requestBody:
         description: License request
         required: true
@@ -822,6 +842,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetAudits
       parameters:
         - name: page
           in: query
@@ -869,6 +890,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: InvalidateCaches
       responses:
         "200":
           description: Caches invalidate successful
@@ -900,6 +922,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetLogs
       parameters:
         - name: page
           in: query
@@ -949,6 +972,7 @@
         Logged in users can log ERROR or DEBUG messages when `ServiceSettings.EnableDeveloper` is `true` or just DEBUG messages when `false`.
 
         Non-logged in users can log ERROR or DEBUG messages when `ServiceSettings.EnableDeveloper` is `true` and cannot log when `false`.
+      operationId: AddLogMessage
       requestBody:
         content:
           application/json:
@@ -1010,6 +1034,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetAnalytics
       parameters:
         - name: name
           in: query
@@ -1050,6 +1075,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: SetServerBusyFlag
       parameters:
         - name: seconds
           in: query
@@ -1098,6 +1124,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetServerBusyExpiryTime
       responses:
         "200":
           description: Server busy expires timestamp retrieved successfully
@@ -1138,6 +1165,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: ClearServerBusyFlag
       responses:
         "200":
           description: Server busy flag cleared successfully
@@ -1172,6 +1200,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: AcknowledgeNotification
       responses:
         "200":
           description: Status of the system
@@ -1192,6 +1221,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetRedirectLocation
       parameters:
         - name: url
           in: query
@@ -1224,6 +1254,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetImageByUrl
       responses:
         "200":
           description: Image found
@@ -1250,6 +1281,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: UpgradeToEnterpriseEdition
       responses:
         "202":
           description: Upgrade started
@@ -1276,6 +1308,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetStatusForUpgradeToEnterpriseEdition
       responses:
         "200":
           description: Upgrade status
@@ -1307,6 +1340,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RestartAfterUpgradeToEnterpriseEdition
       responses:
         "200":
           description: Restart started
@@ -1335,6 +1369,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetWarnMetricsStatus
       responses:
         "200":
           description: Warn metrics retrieval was successful.
@@ -1364,6 +1399,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: AcknowledgeWarningOfMetricStatus
       parameters:
         - name: warn_metric_id
           in: path
@@ -1409,6 +1445,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RequestTrialLicenseAndAcknowledgeWarningOfMetricStatus
       parameters:
         - name: warn_metric_id
           in: path
@@ -1445,6 +1482,7 @@
 
 
         __Local mode only__: This endpoint is only available through [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+      operationId: CheckIntegrity
       responses:
         "200":
           description: Integrity check successful
@@ -1479,6 +1517,7 @@
         Must have any of the system console read permissions.
         ##### License
         Requires either a E10 or E20 license.
+      operationId: DownloadZipFile
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -9,7 +9,7 @@
         ##### Permissions
 
         Must be logged in.
-      operationId: GetSupportedTimezones
+      operationId: GetSupportedTimezone
       responses:
         "200":
           description: List of timezones retrieval successful
@@ -39,7 +39,7 @@
         ##### Permissions
 
         Must be logged in.
-      operationId: GetPingWithServerStatus
+      operationId: GetPing
       parameters:
         - name: get_server_status
           in: query
@@ -271,7 +271,7 @@
 
 
         __Minimum server version__: 5.16
-      operationId: TestSiteUrl
+      operationId: TestSiteURL
       requestBody:
         content:
           application/json:
@@ -481,7 +481,7 @@
         Get a subset of the server configuration needed by the client.
         ##### Permissions
         No permission required.
-      operationId: GetConfigClient
+      operationId: GetClientConfig
       parameters:
         - name: format
           in: query
@@ -526,7 +526,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: GetConfigEnvVariables
+      operationId: GetEnvironmentConfig
       responses:
         "200":
           description: Configuration retrieval successful
@@ -972,7 +972,7 @@
         Logged in users can log ERROR or DEBUG messages when `ServiceSettings.EnableDeveloper` is `true` or just DEBUG messages when `false`.
 
         Non-logged in users can log ERROR or DEBUG messages when `ServiceSettings.EnableDeveloper` is `true` and cannot log when `false`.
-      operationId: AddLogMessage
+      operationId: PostLog
       requestBody:
         content:
           application/json:
@@ -1034,7 +1034,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: GetAnalytics
+      operationId: GetAnalyticsOld
       parameters:
         - name: name
           in: query
@@ -1075,7 +1075,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: SetServerBusyFlag
+      operationId: SetServerBusy
       parameters:
         - name: seconds
           in: query
@@ -1124,7 +1124,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: GetServerBusyExpiryTime
+      operationId: GetServerBusyExpires
       responses:
         "200":
           description: Server busy expires timestamp retrieved successfully
@@ -1165,7 +1165,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: ClearServerBusyFlag
+      operationId: ClearServerBusy
       responses:
         "200":
           description: Server busy flag cleared successfully
@@ -1281,7 +1281,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: UpgradeToEnterpriseEdition
+      operationId: UpgradeToEnterprise
       responses:
         "202":
           description: Upgrade started
@@ -1308,7 +1308,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: GetStatusForUpgradeToEnterpriseEdition
+      operationId: UpgradeToEnterpriseStatus
       responses:
         "200":
           description: Upgrade status
@@ -1340,7 +1340,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: RestartAfterUpgradeToEnterpriseEdition
+      operationId: RestartServer
       responses:
         "200":
           description: Restart started
@@ -1399,7 +1399,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: AcknowledgeWarningOfMetricStatus
+      operationId: SendWarnMetricAck
       parameters:
         - name: warn_metric_id
           in: path
@@ -1445,7 +1445,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
-      operationId: RequestTrialLicenseAndAcknowledgeWarningOfMetricStatus
+      operationId: SendTrialLicenseWarnMetricAck
       parameters:
         - name: warn_metric_id
           in: path
@@ -1517,7 +1517,7 @@
         Must have any of the system console read permissions.
         ##### License
         Requires either a E10 or E20 license.
-      operationId: DownloadZipFile
+      operationId: GenerateSupportPacket
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -7,6 +7,7 @@
         Create a new team on the system.
         ##### Permissions
         Must be authenticated and have the `create_team` permission.
+      operationId: CreateTeam
       requestBody:
         content:
           application/json:
@@ -92,6 +93,7 @@
         ##### Permissions
 
         Must be authenticated. "manage_system" permission is required to show all teams.
+      operationId: GetTeams
       parameters:
         - name: page
           in: query
@@ -177,6 +179,7 @@
         Get a team on the system.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
+      operationId: GetTeam
       parameters:
         - name: team_id
           in: path
@@ -246,6 +249,7 @@
         ##### Permissions
 
         Must have the `manage_team` permission.
+      operationId: UpdateTeam
       parameters:
         - name: team_id
           in: path
@@ -365,6 +369,7 @@
         ##### Permissions
 
         Must have the `manage_team` permission.
+      operationId: DeleteTeam
       parameters:
         - name: team_id
           in: path
@@ -456,6 +461,7 @@
         ##### Permissions
 
         Must have the `manage_team` permission.
+      operationId: PatchTeam
       parameters:
         - name: team_id
           in: path
@@ -556,6 +562,7 @@
         ##### Permissions
 
         `manage_team` permission for the team of the team.
+      operationId: UpdateTeamPrivacy
       parameters:
         - name: team_id
           in: path
@@ -651,6 +658,7 @@
 
         ##### Permissions
         Must have the `manage_team` permission.
+      operationId: RestoreTeam
       parameters:
         - name: team_id
           in: path
@@ -714,6 +722,7 @@
         ##### Permissions
 
         Must be authenticated, team type is open and have the `view_team` permission.
+      operationId: GetTeamByName
       parameters:
         - name: name
           in: path
@@ -778,6 +787,7 @@
         ##### Permissions
         Logged in user only shows open teams
         Logged in user with "manage_system" permission shows all teams
+      operationId: SearchTeams
       requestBody:
         content:
           application/json:
@@ -898,6 +908,7 @@
         Check if the team exists based on a team name.
         ##### Permissions
         Must be authenticated.
+      operationId: CheckTeamExists
       parameters:
         - name: name
           in: path
@@ -960,6 +971,7 @@
         ##### Permissions
 
         Must be authenticated as the user or have the `manage_system` permission.
+      operationId: GetUserTeams
       parameters:
         - name: user_id
           in: path
@@ -1029,6 +1041,7 @@
         ##### Permissions
 
         Must be authenticated and have the `view_team` permission.
+      operationId: GetTeamMembers
       parameters:
         - name: team_id
           in: path
@@ -1113,6 +1126,7 @@
         ##### Permissions
 
         Must be authenticated and team be open to add self. For adding another user, authenticated user must have the `add_user_to_team` permission.
+      operationId: AddTeamMember
       parameters:
         - name: team_id
           in: path
@@ -1198,6 +1212,7 @@
         ##### Permissions
 
         Must be authenticated.
+      operationId: AddTeamMemberFromInvite
       parameters:
         - name: token
           in: query
@@ -1268,6 +1283,7 @@
         ##### Permissions
 
         Must be authenticated. Authenticated user must have the `add_user_to_team` permission.
+      operationId: AddTeamMembers
       parameters:
         - name: team_id
           in: path
@@ -1369,6 +1385,7 @@
         ##### Permissions
 
         Must be logged in as the user or have the `edit_other_users` permission.
+      operationId: GetTeamMembersForUser
       parameters:
         - name: user_id
           in: path
@@ -1437,6 +1454,7 @@
         Get a team member on the system.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
+      operationId: GetTeamMember
       parameters:
         - name: team_id
           in: path
@@ -1513,6 +1531,7 @@
         ##### Permissions
 
         Must be logged in as the user or have the `remove_user_from_team` permission.
+      operationId: RemoveTeamMember
       parameters:
         - name: team_id
           in: path
@@ -1587,6 +1606,7 @@
         Get a list of team members based on a provided array of user ids.
         ##### Permissions
         Must have `view_team` permission for the team.
+      operationId: GetTeamMembersByIds
       parameters:
         - name: team_id
           in: path
@@ -1677,6 +1697,7 @@
         Get a team stats on the system.
         ##### Permissions
         Must be authenticated and have the `view_team` permission.
+      operationId: GetTeamStats
       parameters:
         - name: team_id
           in: path
@@ -1743,6 +1764,7 @@
         Regenerates the invite ID used in invite links of a team
         ##### Permissions
         Must be authenticated and have the `manage_team` permission.
+      operationId: RegenerateTeamInviteId
       parameters:
         - name: team_id
           in: path
@@ -1815,6 +1837,7 @@
         ##### Permissions
 
         User must be authenticated. In addition, team must be open or the user must have the `view_team` permission.
+      operationId: GetTeamIcon
       parameters:
         - name: team_id
           in: path
@@ -1881,6 +1904,7 @@
 
         ##### Permissions
         Must be authenticated and have the `manage_team` permission.
+      operationId: SetTeamIcon
       parameters:
         - name: team_id
           in: path
@@ -1984,6 +2008,7 @@
 
         ##### Permissions
         Must be authenticated and have the `manage_team` permission.
+      operationId: RemoveTeamIcon
       parameters:
         - name: team_id
           in: path
@@ -2056,6 +2081,7 @@
         ##### Permissions
 
         Must be authenticated and have the `manage_team_roles` permission.
+      operationId: UpdateTeamMemberRoles
       parameters:
         - name: team_id
           in: path
@@ -2158,6 +2184,7 @@
         ##### Permissions
 
         Must be authenticated and have the `manage_team_roles` permission.
+      operationId: UpdateSchemeDerivedRolesOfMember
       parameters:
         - name: team_id
           in: path
@@ -2261,6 +2288,7 @@
         ##### Permissions
 
         Must be logged in.
+      operationId: GetTeamsUnreadForUser
       parameters:
         - name: user_id
           in: path
@@ -2340,6 +2368,7 @@
         ##### Permissions
 
         Must be the user or have `edit_other_users` permission and have `view_team` permission for the team.
+      operationId: GetUnreadsForTeam
       parameters:
         - name: user_id
           in: path
@@ -2416,6 +2445,7 @@
         The number of emails that can be sent is rate limited to 20 per hour with a burst of 20 emails. If the rate limit exceeds, the error message contains details on when to retry and when the timer will be reset.
         ##### Permissions
         Must have `invite_user` and `add_user_to_team` permissions for the team.
+      operationId: InviteUsersToTeamByEmail
       parameters:
         - name: team_id
           in: path
@@ -2503,6 +2533,7 @@
 
         ##### Permissions
         Must have `invite_guest` permission for the team.
+      operationId: InviteGuestsToTeamByEmail
       parameters:
         - name: team_id
           in: path
@@ -2611,6 +2642,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
+      operationId: InvalidateActiveEmailInvitations
       responses:
         "200":
           description: Email invites successfully revoked
@@ -2667,6 +2699,7 @@
         ##### Permissions
 
         Must have `permission_import_team` permission.
+      operationId: ImportTeam
       parameters:
         - name: team_id
           in: path
@@ -2791,6 +2824,7 @@
         ##### Permissions
 
         No authentication required.
+      operationId: GetInviteInfoForTeam
       parameters:
         - name: invite_id
           in: path
@@ -2866,6 +2900,7 @@
 
 
         __Minimum server version__: 5.0
+      operationId: SetTeamScheme
       parameters:
         - name: team_id
           in: path
@@ -2967,6 +3002,7 @@
 
 
         __Minimum server version__: 5.14
+      operationId: GetTeamMembersMinusGroupMembers
       parameters:
         - name: team_id
           in: path

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -93,7 +93,7 @@
         ##### Permissions
 
         Must be authenticated. "manage_system" permission is required to show all teams.
-      operationId: GetTeams
+      operationId: GetAllTeams
       parameters:
         - name: page
           in: query
@@ -369,7 +369,7 @@
         ##### Permissions
 
         Must have the `manage_team` permission.
-      operationId: DeleteTeam
+      operationId: SoftDeleteTeam
       parameters:
         - name: team_id
           in: path
@@ -908,7 +908,7 @@
         Check if the team exists based on a team name.
         ##### Permissions
         Must be authenticated.
-      operationId: CheckTeamExists
+      operationId: TeamExists
       parameters:
         - name: name
           in: path
@@ -971,7 +971,7 @@
         ##### Permissions
 
         Must be authenticated as the user or have the `manage_system` permission.
-      operationId: GetUserTeams
+      operationId: GetTeamsForUser
       parameters:
         - name: user_id
           in: path
@@ -2184,7 +2184,7 @@
         ##### Permissions
 
         Must be authenticated and have the `manage_team_roles` permission.
-      operationId: UpdateSchemeDerivedRolesOfMember
+      operationId: UpdateTeamMemberSchemeRoles
       parameters:
         - name: team_id
           in: path
@@ -2368,7 +2368,7 @@
         ##### Permissions
 
         Must be the user or have `edit_other_users` permission and have `view_team` permission for the team.
-      operationId: GetUnreadsForTeam
+      operationId: GetTeamUnread
       parameters:
         - name: user_id
           in: path
@@ -2445,7 +2445,7 @@
         The number of emails that can be sent is rate limited to 20 per hour with a burst of 20 emails. If the rate limit exceeds, the error message contains details on when to retry and when the timer will be reset.
         ##### Permissions
         Must have `invite_user` and `add_user_to_team` permissions for the team.
-      operationId: InviteUsersToTeamByEmail
+      operationId: InviteUsersToTeam
       parameters:
         - name: team_id
           in: path
@@ -2533,7 +2533,7 @@
 
         ##### Permissions
         Must have `invite_guest` permission for the team.
-      operationId: InviteGuestsToTeamByEmail
+      operationId: InviteGuestsToTeam
       parameters:
         - name: team_id
           in: path
@@ -2642,7 +2642,7 @@
         ##### Permissions
 
         Must have `sysconsole_write_authentication` permission.
-      operationId: InvalidateActiveEmailInvitations
+      operationId: InvalidateEmailInvites
       responses:
         "200":
           description: Email invites successfully revoked
@@ -2824,7 +2824,7 @@
         ##### Permissions
 
         No authentication required.
-      operationId: GetInviteInfoForTeam
+      operationId: GetTeamInviteInfo
       parameters:
         - name: invite_id
           in: path
@@ -2900,7 +2900,7 @@
 
 
         __Minimum server version__: 5.0
-      operationId: SetTeamScheme
+      operationId: UpdateTeamScheme
       parameters:
         - name: team_id
           in: path
@@ -3002,7 +3002,7 @@
 
 
         __Minimum server version__: 5.14
-      operationId: GetTeamMembersMinusGroupMembers
+      operationId: TeamMembersMinusGroupMembers
       parameters:
         - name: team_id
           in: path

--- a/v4/source/uploads.yaml
+++ b/v4/source/uploads.yaml
@@ -85,7 +85,7 @@
 
         ##### Permissions
         Must be logged in as the user who created the upload session.
-      operationId: GetUploadSession
+      operationId: GetUpload
       parameters:
         - name: upload_id
           in: path
@@ -133,7 +133,7 @@
 
         ##### Permissions
         Must be logged in as the user who created the upload session.
-      operationId: PerformFileUpload
+      operationId: UploadData
       parameters:
         - name: upload_id
           in: path

--- a/v4/source/uploads.yaml
+++ b/v4/source/uploads.yaml
@@ -13,6 +13,7 @@
 
         Must have `upload_file` permission.
 
+      operationId: CreateUpload
       requestBody:
         content:
           application/json:
@@ -84,6 +85,7 @@
 
         ##### Permissions
         Must be logged in as the user who created the upload session.
+      operationId: GetUploadSession
       parameters:
         - name: upload_id
           in: path
@@ -131,6 +133,7 @@
 
         ##### Permissions
         Must be logged in as the user who created the upload session.
+      operationId: PerformFileUpload
       parameters:
         - name: upload_id
           in: path

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -7,6 +7,7 @@
         ##### Permissions
 
         No permission required
+      operationId: Login
       requestBody:
         content:
           application/json:
@@ -51,6 +52,7 @@
         ##### Permissions
 
         A Cloud license is required
+      operationId: LoginCwsToken
       requestBody:
         content:
           application/json:
@@ -81,6 +83,7 @@
         ##### Permissions
 
         An active session is required
+      operationId: Logout
       responses:
         "201":
           description: User logout successful
@@ -106,6 +109,7 @@
         ##### Permissions
 
         No permission required but user creation can be controlled by server configuration.
+      operationId: CreateUser
       parameters:
         - name: t
           in: query
@@ -221,6 +225,7 @@
         ##### Permissions
 
         Requires an active session and (if specified) membership to the channel or team being selected from.
+      operationId: GetUsers
       parameters:
         - name: page
           in: query
@@ -467,6 +472,7 @@
 
 
         __Local mode only__: This endpoint is only available through [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+      operationId: PermanentDeleteAllUsers
       responses:
         "200":
           description: Delete request was successful
@@ -499,6 +505,7 @@
         Get a list of users based on a provided list of user ids.
         ##### Permissions
         Requires an active session but no other permissions.
+      operationId: GetUsersByIds
       parameters:
         - name: since
           in: query
@@ -548,6 +555,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 5.14
+      operationId: GetUsersByGroupChannels
       requestBody:
         content:
           application/json:
@@ -582,6 +590,7 @@
         Get a list of users based on a provided list of usernames.
         ##### Permissions
         Requires an active session but no other permissions.
+      operationId: GetUsersByUsernames
       requestBody:
         content:
           application/json:
@@ -654,6 +663,7 @@
         ##### Permissions
 
         Requires an active session and `read_channel` and/or `view_team` permissions for any channels or teams specified in the request body.
+      operationId: SearchUsers
       requestBody:
         content:
           application/json:
@@ -794,6 +804,7 @@
         ##### Permissions
 
         Requires an active session and `view_team` and `read_channel` on any teams or channels used to filter the results further.
+      operationId: AutocompleteUsers
       parameters:
         - name: team_id
           in: query
@@ -897,6 +908,7 @@
         Must be authenticated.
 
         __Minimum server version__: 5.23
+      operationId: GetKnownUsers
       responses:
         "200":
           description: Known users' IDs retrieval successful
@@ -925,6 +937,7 @@
         Get a total count of users in the system.
         ##### Permissions
         Must be authenticated.
+      operationId: GetTotalCountOfUsersInSystem
       responses:
         "200":
           description: User stats retrieval successful
@@ -983,6 +996,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: GetTotalCountOfUsersInSystemMatchingFilters
       parameters:
         - name: in_team
           in: query
@@ -1055,6 +1069,7 @@
         Get a user a object. Sensitive information will be sanitized out.
         ##### Permissions
         Requires an active session but no other permissions.
+      operationId: GetUser
       parameters:
         - name: user_id
           in: path
@@ -1123,6 +1138,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: UpdateUser
       parameters:
         - name: user_id
           in: path
@@ -1265,6 +1281,7 @@
         ##### Permissions
 
         Must be logged in as the user being deactivated or have the `edit_other_users` permission.
+      operationId: DeactivateUserAccount
       parameters:
         - name: user_id
           in: path
@@ -1335,6 +1352,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: PatchUser
       parameters:
         - name: user_id
           in: path
@@ -1463,6 +1481,7 @@
         ##### Permissions
 
         Must have the `manage_roles` permission.
+      operationId: UpdateUserRoles
       parameters:
         - name: user_id
           in: path
@@ -1550,6 +1569,7 @@
         User can deactivate themselves.
 
         User with `manage_system` permission can activate or deactivate a user.
+      operationId: UpdateUserActiveStatus
       parameters:
         - name: user_id
           in: path
@@ -1628,6 +1648,7 @@
         Get a user's profile image based on user_id string parameter.
         ##### Permissions
         Must be logged in.
+      operationId: GetUserProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1693,6 +1714,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: SetUserProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1798,6 +1820,7 @@
         Must be logged in as the user being updated or have the `edit_other_users` permission.
 
         __Minimum server version__: 5.5
+      operationId: DeleteUserProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1877,6 +1900,7 @@
         Must be logged in.
 
         __Minimum server version__: 5.5
+      operationId: ReturnUserDefaultProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1944,6 +1968,7 @@
         ##### Permissions
 
         Requires an active session but no other permissions.
+      operationId: GetUserByUsername
       parameters:
         - name: username
           in: path
@@ -2011,6 +2036,7 @@
         ##### Permissions
 
         No permissions required.
+      operationId: ResetPassword
       requestBody:
         content:
           application/json:
@@ -2093,6 +2119,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: UpdateUserMfa
       parameters:
         - name: user_id
           in: path
@@ -2183,6 +2210,7 @@
         ##### Permissions
 
         Must be logged in as the user or have the `edit_other_users` permission.
+      operationId: GenerateMfaSecret
       parameters:
         - name: user_id
           in: path
@@ -2263,6 +2291,7 @@
 
         ##### Permissions
         Must be logged in as the user or have the `demote_to_guest` permission.
+      operationId: DemoteUserToGuest
       parameters:
         - name: user_id
           in: path
@@ -2336,6 +2365,7 @@
 
         ##### Permissions
         Must be logged in as the user or have the `promote_guest` permission.
+      operationId: PromoteGuestToUser
       parameters:
         - name: user_id
           in: path
@@ -2408,6 +2438,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
+      operationId: ConvertUserToBot
       parameters:
         - name: user_id
           in: path
@@ -2453,6 +2484,7 @@
         ##### Permissions
 
         No permission required.
+      operationId: CheckMfa
       requestBody:
         content:
           application/json:
@@ -2527,6 +2559,7 @@
         ##### Permissions
 
         Must be logged in as the user the password is being changed for or have `manage_system` permission.
+      operationId: UpdateUserPassword
       parameters:
         - name: user_id
           in: path
@@ -2623,6 +2656,7 @@
         ##### Permissions
 
         No permissions required.
+      operationId: SendPasswordResetEmail
       requestBody:
         content:
           application/json:
@@ -2696,6 +2730,7 @@
         ##### Permissions
 
         Requires an active session and for the current session to be able to view another user's email based on the server's privacy settings.
+      operationId: GetUserByEmail
       parameters:
         - name: email
           in: path
@@ -2765,6 +2800,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: GetUserSessions
       parameters:
         - name: user_id
           in: path
@@ -2833,6 +2869,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
+      operationId: RevokeUserSession
       parameters:
         - name: user_id
           in: path
@@ -2918,6 +2955,7 @@
         Must be logged in as the user being updated or have the `edit_other_users` permission.
 
         __Minimum server version__: 4.4
+      operationId: RevokeAllUserSessions
       parameters:
         - name: user_id
           in: path
@@ -2985,6 +3023,7 @@
         ##### Permissions
 
         Must be authenticated.
+      operationId: AttachMobileDevice
       requestBody:
         content:
           application/json:
@@ -3055,6 +3094,7 @@
         Get a list of audit by providing the user GUID.
         ##### Permissions
         Must be logged in as the user or have the `edit_other_users` permission.
+      operationId: GetUserAudits
       parameters:
         - name: user_id
           in: path
@@ -3125,6 +3165,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: VerifyUserEmailWithoutToken
       parameters:
         - name: user_id
           in: path
@@ -3165,6 +3206,7 @@
         Verify the email used by a user to sign-up their account with.
         ##### Permissions
         No permissions required.
+      operationId: VerifyUserEmail
       requestBody:
         content:
           application/json:
@@ -3235,6 +3277,7 @@
         ##### Permissions
 
         No permissions required.
+      operationId: SendVerificationEmail
       requestBody:
         content:
           application/json:
@@ -3322,6 +3365,7 @@
         ##### Permissions
 
         No current authentication required except when switching from OAuth2/SAML to email.
+      operationId: SwitchLoginMethod
       requestBody:
         content:
           application/json:
@@ -3448,6 +3492,7 @@
         ##### Permissions
 
         Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: CreateUserAccessToken
       parameters:
         - name: user_id
           in: path
@@ -3536,6 +3581,7 @@
         ##### Permissions
 
         Must have `read_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: GetUserAccessTokensForUser
       parameters:
         - name: user_id
           in: path
@@ -3625,6 +3671,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: GetUserAccessTokens
       parameters:
         - name: page
           in: query
@@ -3677,6 +3724,7 @@
         ##### Permissions
 
         Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: RevokeUserAccessToken
       requestBody:
         content:
           application/json:
@@ -3755,6 +3803,7 @@
         ##### Permissions
 
         Must have `read_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: GetUserAccessToken
       parameters:
         - name: token_id
           in: path
@@ -3828,6 +3877,7 @@
         ##### Permissions
 
         Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: DisablePersonalAccessToken
       requestBody:
         content:
           application/json:
@@ -3905,6 +3955,7 @@
         ##### Permissions
 
         Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+      operationId: EnablePersonalAccessToken
       requestBody:
         content:
           application/json:
@@ -3983,6 +4034,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: SearchUserAccessTokens
       requestBody:
         content:
           application/json:
@@ -4062,6 +4114,7 @@
         ##### Permissions
 
         Must have the `edit_other_users` permission.
+      operationId: UpdateUserAuthenticationMethod
       parameters:
         - name: user_id
           in: path
@@ -4158,6 +4211,7 @@
         ##### Permissions
 
         Must be logged in as the user being acted on.
+      operationId: RegisterTermsOfServiceAction
       parameters:
         - name: user_id
           in: path
@@ -4230,6 +4284,7 @@
         ##### Permissions
 
         Must be logged in as the user being acted on.
+      operationId: GetUserTermsOfService
       parameters:
         - name: user_id
           in: path
@@ -4283,6 +4338,7 @@
         ##### Permissions
 
         Must have `manage_system` permission.
+      operationId: RevokeSessionsFromAllUsers
       responses:
         "200":
           description: Sessions successfully revoked.
@@ -4314,6 +4370,7 @@
 
         Must have `manage_system` permission to publish for any user other than oneself.
 
+      operationId: PublishUserTyping
       parameters:
         - name: user_id
           in: path
@@ -4369,6 +4426,7 @@
 
         ##### Permissions
         Must be logged in as the user who created the upload sessions.
+      operationId: GetUploadsForUser
       parameters:
         - name: user_id
           in: path
@@ -4425,6 +4483,7 @@
 
         Must have `manage_system` permission.
 
+      operationId: MigrateAuthToLdap
       requestBody:
           content:
             application/json:
@@ -4482,6 +4541,7 @@
 
           Must have `manage_system` permission.
 
+        operationId: MigrateAuthToSaml
         requestBody:
             content:
               application/json:
@@ -4533,6 +4593,7 @@
 
       ##### Permissions
       Must be logged in as the user or have `edit_other_users` permission.
+    operationId: GetUserThreads
     parameters:
       - name: user_id
         in: path
@@ -4625,6 +4686,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: GetThreadMentionsForUserPerChannel
       parameters:
         - name: user_id
           in: path
@@ -4674,6 +4736,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: MarkThreadsReadForUser
       parameters:
         - name: user_id
           in: path
@@ -4723,6 +4786,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: MarkThreadReadForUser
       parameters:
         - name: user_id
           in: path
@@ -4784,6 +4848,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: StartFollowingThread
       parameters:
         - name: user_id
           in: path
@@ -4838,6 +4903,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: StopFollowingThread
       parameters:
         - name: user_id
           in: path
@@ -4893,6 +4959,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
+      operationId: GetUserThread
       parameters:
         - name: user_id
           in: path

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -52,7 +52,7 @@
         ##### Permissions
 
         A Cloud license is required
-      operationId: LoginCwsToken
+      operationId: LoginByCwsToken
       requestBody:
         content:
           application/json:
@@ -555,7 +555,7 @@
         Requires an active session but no other permissions.
 
         __Minimum server version__: 5.14
-      operationId: GetUsersByGroupChannels
+      operationId: GetUsersByGroupChannelIds
       requestBody:
         content:
           application/json:
@@ -937,7 +937,7 @@
         Get a total count of users in the system.
         ##### Permissions
         Must be authenticated.
-      operationId: GetTotalCountOfUsersInSystem
+      operationId: GetTotalUsersStats
       responses:
         "200":
           description: User stats retrieval successful
@@ -996,7 +996,7 @@
 
         ##### Permissions
         Must have `manage_system` permission.
-      operationId: GetTotalCountOfUsersInSystemMatchingFilters
+      operationId: GetTotalUsersStatsFiltered
       parameters:
         - name: in_team
           in: query
@@ -1281,7 +1281,7 @@
         ##### Permissions
 
         Must be logged in as the user being deactivated or have the `edit_other_users` permission.
-      operationId: DeactivateUserAccount
+      operationId: DeleteUser
       parameters:
         - name: user_id
           in: path
@@ -1569,7 +1569,7 @@
         User can deactivate themselves.
 
         User with `manage_system` permission can activate or deactivate a user.
-      operationId: UpdateUserActiveStatus
+      operationId: UpdateUserActive
       parameters:
         - name: user_id
           in: path
@@ -1648,7 +1648,7 @@
         Get a user's profile image based on user_id string parameter.
         ##### Permissions
         Must be logged in.
-      operationId: GetUserProfileImage
+      operationId: GetProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1714,7 +1714,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: SetUserProfileImage
+      operationId: SetProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1820,7 +1820,7 @@
         Must be logged in as the user being updated or have the `edit_other_users` permission.
 
         __Minimum server version__: 5.5
-      operationId: DeleteUserProfileImage
+      operationId: SetDefaultProfileImage
       parameters:
         - name: user_id
           in: path
@@ -1900,7 +1900,7 @@
         Must be logged in.
 
         __Minimum server version__: 5.5
-      operationId: ReturnUserDefaultProfileImage
+      operationId: GetDefaultProfileImage
       parameters:
         - name: user_id
           in: path
@@ -2484,7 +2484,7 @@
         ##### Permissions
 
         No permission required.
-      operationId: CheckMfa
+      operationId: CheckUserMfa
       requestBody:
         content:
           application/json:
@@ -2800,7 +2800,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: GetUserSessions
+      operationId: GetSessions
       parameters:
         - name: user_id
           in: path
@@ -2869,7 +2869,7 @@
         ##### Permissions
 
         Must be logged in as the user being updated or have the `edit_other_users` permission.
-      operationId: RevokeUserSession
+      operationId: RevokeSession
       parameters:
         - name: user_id
           in: path
@@ -2955,7 +2955,7 @@
         Must be logged in as the user being updated or have the `edit_other_users` permission.
 
         __Minimum server version__: 4.4
-      operationId: RevokeAllUserSessions
+      operationId: RevokeAllSessions
       parameters:
         - name: user_id
           in: path
@@ -3023,7 +3023,7 @@
         ##### Permissions
 
         Must be authenticated.
-      operationId: AttachMobileDevice
+      operationId: AttachDeviceId
       requestBody:
         content:
           application/json:
@@ -3365,7 +3365,7 @@
         ##### Permissions
 
         No current authentication required except when switching from OAuth2/SAML to email.
-      operationId: SwitchLoginMethod
+      operationId: SwitchAccountType
       requestBody:
         content:
           application/json:
@@ -3877,7 +3877,7 @@
         ##### Permissions
 
         Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
-      operationId: DisablePersonalAccessToken
+      operationId: DisableUserAccessToken
       requestBody:
         content:
           application/json:
@@ -3955,7 +3955,7 @@
         ##### Permissions
 
         Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
-      operationId: EnablePersonalAccessToken
+      operationId: EnableUserAccessToken
       requestBody:
         content:
           application/json:
@@ -4114,7 +4114,7 @@
         ##### Permissions
 
         Must have the `edit_other_users` permission.
-      operationId: UpdateUserAuthenticationMethod
+      operationId: UpdateUserAuth
       parameters:
         - name: user_id
           in: path
@@ -4686,7 +4686,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
-      operationId: GetThreadMentionsForUserPerChannel
+      operationId: GetThreadMentionCountsByChannel
       parameters:
         - name: user_id
           in: path
@@ -4736,7 +4736,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
-      operationId: MarkThreadsReadForUser
+      operationId: UpdateThreadsReadForUser
       parameters:
         - name: user_id
           in: path
@@ -4786,7 +4786,7 @@
 
         ##### Permissions
         Must be logged in as the user or have `edit_other_users` permission.
-      operationId: MarkThreadReadForUser
+      operationId: UpdateThreadReadForUser
       parameters:
         - name: user_id
           in: path
@@ -5018,6 +5018,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetTeamPoliciesForUser
       parameters:
         - name: user_id
           in: path
@@ -5067,6 +5068,7 @@
 
         ##### License
         Requires an E20 license.
+      operationId: GetChannelPoliciesForUser
       parameters:
         - name: user_id
           in: path

--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -9,6 +9,7 @@
         `manage_webhooks` for the team the webhook is in.
 
         `manage_others_incoming_webhooks` for the team the webhook is in if the user is different than the requester.
+      operationId: CreateIncomingWebhook
       requestBody:
         content:
           application/json:
@@ -63,6 +64,7 @@
         ##### Permissions
 
         `manage_webhooks` for the system or `manage_webhooks` for the specific team.
+      operationId: GetIncomingWebhooks
       parameters:
         - name: page
           in: query
@@ -107,6 +109,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: GetIncomingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -139,6 +142,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: DeleteIncomingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -171,6 +175,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: UpdateIncomingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -237,6 +242,7 @@
         `manage_webhooks` for the team the webhook is in.
 
         `manage_others_outgoing_webhooks` for the team the webhook is in if the user is different than the requester.
+      operationId: CreateOutgoingWebhook
       requestBody:
         content:
           application/json:
@@ -312,6 +318,7 @@
         ##### Permissions
 
         `manage_webhooks` for the system or `manage_webhooks` for the specific team/channel.
+      operationId: GetOutgoingWebhooks
       parameters:
         - name: page
           in: query
@@ -363,6 +370,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: GetOutgoingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -395,6 +403,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: DeleteOutgoingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -427,6 +436,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: UpdateOutgoingWebhook
       parameters:
         - name: hook_id
           in: path
@@ -486,6 +496,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+      operationId: RegenerateTokenForOutgoingWebhook
       parameters:
         - name: hook_id
           in: path

--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -496,7 +496,7 @@
         ##### Permissions
 
         `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
-      operationId: RegenerateTokenForOutgoingWebhook
+      operationId: RegenOutgoingHookToken
       parameters:
         - name: hook_id
           in: path


### PR DESCRIPTION
#### Summary

+ adds operationIds to the API endpoints. The issue of missing Ids was already discussed in #88 