### PR TITLE
MM-35802 Rename json fields for GetAllSharedChannels to match other channel objects

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -3263,7 +3263,7 @@ components:
     SharedChannel:
       type: object
       properties:
-        channel_id:
+        id:
           description: Channel id of the shared channel
           type: string
         team_id:
@@ -3274,15 +3274,15 @@ components:
         readonly:
           description: Is this shared channel shared as read only
           type: boolean
-        share_name:
+        name:
           description: Channel name as it is shared (may be different than original channel name)
           type: string
-        share_displayname:
+        display_name:
           description: Channel display name as it appears locally
           type: string
-        share_purpose:
+        purpose:
           type: string
-        share_header:
+        header:
           type: string
         creator_id:
           description: Id of the user that shared the channel


### PR DESCRIPTION
#### Summary
Mobile team has requested that `model.SharedChannel` serialize to JSON using the same field names as other Channel objects. i.e.`GetAllSharedChannels` should have matching field names returned as `GetPublicChannels` for any fields they have in common.

This PR updates the API documentation to reflect the modified field names.

Server PR: https://github.com/mattermost/mattermost-server/pull/17634

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35802