### PR TITLE
[MM-29217] Remove Posts.ParentId

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -296,8 +296,6 @@ components:
           type: string
         root_id:
           type: string
-        parent_id:
-          type: string
         original_id:
           type: string
         message:


### PR DESCRIPTION
#### Summary

Removing the deprecated `Posts.ParentId`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-29217

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/17923
https://github.com/mattermost/enterprise/pull/1019
https://github.com/mattermost/mattermost-webapp/pull/8401
https://github.com/mattermost/mattermost-mobile/pull/5541