### PR TITLE
MM-36446: Deprecate Post.Fieldnames field.

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -306,12 +306,6 @@ components:
           type: object
         hashtag:
           type: string
-        filenames:
-          description: This field will only appear on some posts created before Mattermost
-            3.5 and has since been deprecated.
-          type: array
-          items:
-            type: string
         file_ids:
           type: array
           items:


### PR DESCRIPTION
#### Summary

Removes the `Post.Filenames` field.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36446

#### Related PR

https://github.com/mattermost/mattermost-server/pull/17985