### PR TITLE
Clarify how to change system configuration

### DIFF
--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -404,6 +404,12 @@
         4.8, the `PluginSettings.EnableUploads` setting cannot be modified by
         this endpoint.
 
+        Note that the parameters that aren't set in the configuration that you
+        provide will be reset to default values. Therefore, if you want to
+        change a configuration parameter and leave the other ones unchanged,
+        you need to get the existing configuration first, change the field that
+        you want, then put that new configuration.
+
         ##### Permissions
 
         Must have `manage_system` permission.


### PR DESCRIPTION
It took me a while to realize that the whole configuration should
be specified when doing a PUT (not just the fields that one wants
to change). Here is a small paragraph explaining that, hoping to
help others.

It looks like secret parameters (passwords, keys?) are automatically
replaced with strings of asterisks (`**********...`) and that these
get ignored when we PUT a new configuration, but I'm not sure.
If someone knows for sure, it would be fantastic to clarify as well.

Thanks! ♥
