### PR TITLE
Add operationId to /roles

### DIFF
--- a/v4/source/roles.yaml
+++ b/v4/source/roles.yaml
@@ -9,6 +9,7 @@
         `manage_system` permission is required.
 
         __Minimum server version__: 5.33
+      operationId: GetAllRoles
       responses:
         "200":
           description: Roles retrieval successful


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adds an `operationId` field to the API `/roles` call, arbitrarily called `GetAllRoles` by similarity to other API endpoints (e.g. `GetAllChannels`, `GetAllTeams`, ...).

