### PR TITLE
Clarified create user docs for authentication

### DIFF
--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -108,7 +108,7 @@
 
         ##### Permissions
 
-        No permission required but user creation can be controlled by server configuration.
+        No permission required for creating email/username accounts on an open server. Auth Token is required for other authenticate types such as LDAP or SAML.
       operationId: CreateUser
       parameters:
         - name: t

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -108,7 +108,7 @@
 
         ##### Permissions
 
-        No permission required for creating email/username accounts on an open server. Auth Token is required for other authenticate types such as LDAP or SAML.
+        No permission required for creating email/username accounts on an open server. Auth Token is required for other authentication types such as LDAP or SAML.
       operationId: CreateUser
       parameters:
         - name: t


### PR DESCRIPTION
The API requires a personal access token when creating accounts using auth services such as LDAP.