### PR TITLE
Add missing types to array definitions in channels and dataretention

### DIFF
--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -269,6 +269,8 @@
                     parameter to true.
                 team_ids:
                   type: array
+                  items:
+                    type: string
                   description: >
                     Filters results to channels belonging to the given team ids
 

--- a/v4/source/dataretention.yaml
+++ b/v4/source/dataretention.yaml
@@ -641,6 +641,8 @@
                   description: The string to search in the channel name, display name, and purpose.
                 team_ids:
                   type: array
+                  items:
+                    type: string
                   description: >
                     Filters results to channels belonging to the given team ids
                 public:


### PR DESCRIPTION
#### Summary

Add missing item type to `team_ids` arrays in `SearchChannelsForRetentionPolicy` and `SearchAllChannels`. This provides a partial fix for #640 