### PR TITLE
Replaced http URLs with https in various places

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Mattermost API Documentation
 
-This respository holds the API reference available at [https://api.mattermost.com](https://api.mattermost.com).
+This repository holds the API reference available at [https://api.mattermost.com](https://api.mattermost.com).
 
 The Mattermost API reference uses the [OpenAPI standard](https://openapis.org/) and the [ReDoc document generator](https://github.com/Rebilly/ReDoc).
 
-All documentation is available under the terms of a [Creative Commons License](http://creativecommons.org/licenses/by-nc-sa/3.0/).
+All documentation is available under the terms of a [Creative Commons License](https://creativecommons.org/licenses/by-nc-sa/3.0/).
 
 ## Contributing
 

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -9,7 +9,7 @@ info:
   contact:
     email: feedback@mattermost.com
   x-logo:
-    url: http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png
+    url: https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png
     backgroundColor: "#FFFFFF"
 tags:
   - name: introduction
@@ -25,7 +25,7 @@ tags:
       Mattermost core committers work with the community to keep the API documentation up-to-date.
 
 
-      If you have questions on API routes not listed in this reference, please [join the Mattermost community server](https://pre-release.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) to ask questions in the Developers channel, [or post questions to our Developer Discussion forum](http://forum.mattermost.org/c/dev).
+      If you have questions on API routes not listed in this reference, please [join the Mattermost community server](https://pre-release.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) to ask questions in the Developers channel, [or post questions to our Developer Discussion forum](https://forum.mattermost.org/c/dev).
 
 
       [Bug reports](https://github.com/mattermost/mattermost-api-reference/issues) in the documentation or the API are also welcome, as are pull requests to fix the issues.


### PR DESCRIPTION
#### Summary
After the http conversation I noticed a few urls are still http in this repo. I tried to get the ones that wouldn't cause an issue and updated them here. 

The `redoc-static.html` seems like it also has a ton of urls to update, but changing those didn't feed into the output `index.html`, so i'm not exactly sure where to make that change. It has a lot of URLS like `http://www.w3.org/2000/svg` that can be changed, and some in the scripts themselves.


