### PR TITLE
update GetEmojiList's per_page to refer to emojis

### DIFF
--- a/v4/source/emoji.yaml
+++ b/v4/source/emoji.yaml
@@ -64,7 +64,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page.
+          description: The number of emojis per page.
           schema:
             type: integer
             default: 60


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes a typo in a parameter description for the GetEmojiList operation. The parameter in question is the `per_page` parameter, which should specify the number of *emojis* per page, but instead the current API reference says *users* per page.

#### Ticket Link
No ticket involved.

