### PR TITLE
[MM-42742] Top Reactions Documentation

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -771,6 +771,16 @@ components:
           description: The time in milliseconds this reaction was made
           type: integer
           format: int64
+    TopReaction:
+      type: object
+      properties:
+        emoji_name:
+          description: The name of the emoji that was used for this reaction
+          type: string
+        count:
+          description: The number of the times this emoji was used
+          type: integer
+          format: int64
     Emoji:
       type: object
       properties:

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -27,6 +27,126 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+  "/reactions/top/team/{team_id}":
+    get:
+      tags:
+        - reactions
+      summary: Get a list of the top reactions for a team
+      description: |
+        Get a list of the top reactions across all public channels, and private channels (that the user is a member of) for a given team.
+        ##### Permissions
+        Must have `view_team` permission for the team.
+      operationId: GetTopReactionsForTeam
+      parameters:
+        - name: team_id
+          in: path
+          description: Team GUID
+          required: true
+          schema:
+            type: string
+        - name: time_range
+          in: query
+          description: >
+            Time Range can be "1_day", "7_day" or "30_day".
+
+            - `1_day`: reactions posted in the last 24 hours
+            
+            - `7_day`: reactions posted in the last 7 days
+            
+            - `30_day`: reactions posted in the last 30 days
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: The page to select.
+          schema:
+            type: integer
+            default: 0
+        - name: per_page
+          in: query
+          description: The number of reactions per page. There is a maximum limit of 200 reactions per page.
+          schema:
+            type: integer
+            default: 60
+      responses:
+        "200":
+          description: Top reactions retrieve successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TopReaction"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  "/reactions/top/team/{user_id}":
+    get:
+      tags:
+        - reactions
+      summary: Get a list of the top reactions for a user
+      description: |
+        Get a list of the top reactions for a user.
+        ##### Permissions
+        Must be logged in as the user or have the `view_members` permission to view the given user.
+      operationId: GetTopReactionsForUser
+      parameters:
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          schema:
+            type: string
+        - name: time_range
+          in: query
+          description: >
+            Time Range can be "1_day", "7_day" or "30_day".
+
+            - `1_day`: reactions posted in the last 24 hours
+            
+            - `7_day`: reactions posted in the last 7 days
+            
+            - `30_day`: reactions posted in the last 30 days
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: The page to select.
+          schema:
+            type: integer
+            default: 0
+        - name: per_page
+          in: query
+          description: The number of reactions per page. There is a maximum limit of 200 reactions per page.
+          schema:
+            type: integer
+            default: 60
+        - name: team_id
+          in: query
+          description: >
+            Team ID will scope the response to a given team.
+
+            ##### Permissions
+
+            Must have `view_team` permission for the team.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Top reactions retrieve successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TopReaction"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   "/posts/{post_id}/reactions":
     get:
       tags:

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -47,13 +47,13 @@
         - name: time_range
           in: query
           description: >
-            Time Range can be "1_day", "7_day" or "30_day".
+            Time Range can be "1_day", "7_day" or "28_day".
 
             - `1_day`: reactions posted in the last 24 hours
             
             - `7_day`: reactions posted in the last 7 days
             
-            - `30_day`: reactions posted in the last 30 days
+            - `28_day`: reactions posted in the last 28 days
           required: true
           schema:
             type: string
@@ -102,13 +102,13 @@
         - name: time_range
           in: query
           description: >
-            Time Range can be "1_day", "7_day" or "30_day".
+            Time Range can be "1_day", "7_day" or "28_day".
 
             - `1_day`: reactions posted in the last 24 hours
             
             - `7_day`: reactions posted in the last 7 days
             
-            - `30_day`: reactions posted in the last 30 days
+            - `28_day`: reactions posted in the last 30 days
           required: true
           schema:
             type: string


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Adds new endpoint to get top reactions for a team and user.

Reference: [tech-specs/activity-and-insights/widgets/top-reactions.md#rest-apis](https://github.com/mkraft/suite-users/blob/main/tech-specs/activity-and-insights-widgets/top-reactions.md#rest-apis)

This adds two new endpoints:
 `GET /api/v4/reactions/top/team/:team_id` and `GET /api/v4/reactions/top/team/:user_id`.
 
Top reactions for a user can also be scoped to a team by adding the `team_id` as a parameter to the request.

This also introduces a new parameter `time_range`, which scopes the request to reactions from a certain time_range.
- `1_day`: Last 24 hours
- `7_day`: Last 7 days
- `28_day`: Last 28 days

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [MM-42742](https://mattermost.atlassian.net/browse/MM-42742)
