### PR TITLE
[MM-42191]: Add includeDeleted parameter

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -574,7 +574,7 @@
           description: A post id to select the posts that came after this one
           schema:
             type: string
-        - name: includeDeleted
+        - name: include_deleted
           in: query
           description: Whether to include deleted posts or not. Must have system admin permissions.
           schema:

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -574,6 +574,12 @@
           description: A post id to select the posts that came after this one
           schema:
             type: string
+        - name: includeDeleted
+          in: query
+          description: Whether to include deleted posts or not. Must have system admin permissions.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Post list retrieval successful


### PR DESCRIPTION
#### Summary
A new query parameter is being added to the endpoint `/api/v4/channels/{channel_id}/posts`. Deleted posts can be included as long as system admins request them.

The new query parameter is added here: https://github.com/mattermost/mattermost-server/pull/19985
 
#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-42191](https://mattermost.atlassian.net/browse/MM-42191)