### PR TITLE
Clarify Websocket authentification methods

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -250,7 +250,7 @@ tags:
       #### Authentication
 
 
-      The Mattermost WebSocket can be authenticated by cookie or through an authentication challenge. If you're authenticating from a browser and have logged in with the Mattermost API, your authentication cookie should already be set, this is how the Mattermost webapp authenticates with the WebSocket.
+      The Mattermost WebSocket can be authenticated using [the standard API authentification methods](/#tag/authentication) (by a cookie, or with an explicit Authorization header), or through an authentication challenge. If you're authenticating from a browser and have logged in with the Mattermost API, your authentication cookie should already be set. This is how the Mattermost webapp authenticates with the WebSocket.
 
 
       To authenticate with an authentication challenge, first connect the WebSocket and then send the following JSON over the connection:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Clarifies that authentication to Websocket can be performed using standard API authentication methods (and not just cookie or the challenge).


