### PR TITLE
[MM-42194] Added documentation for new 'include_deleted' query param on get file info api

### DIFF
--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -505,6 +505,13 @@
           required: true
           schema:
             type: string
+        - name: include_deleted
+          in: query
+          description: Defines if result should include deleted posts.
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: File info retrieval successful

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -507,7 +507,7 @@
             type: string
         - name: include_deleted
           in: query
-          description: Defines if result should include deleted posts.
+          description: Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
           required: false
           schema:
             type: boolean


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Added documentation for new 'include_deleted' query param on get file info api

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/20231

https://mattermost.atlassian.net/browse/MM-42194

