### PR TITLE
[MM-42792] Modified notify_props docs to include only strings, not booleans

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -2381,7 +2381,7 @@ components:
       type: object
       properties:
         email:
-          type: boolean
+          type: string
           description: Set to "true" to enable email notifications, "false" to disable.
             Defaults to "true".
         push:
@@ -2395,7 +2395,7 @@ components:
             "mention" for mentions and direct messages only, and "none" to
             disable. Defaults to "all".
         desktop_sound:
-          type: boolean
+          type: string
           description: Set to "true" to enable sound on desktop notifications, "false" to
             disable. Defaults to "true".
         mention_keys:
@@ -2403,11 +2403,11 @@ components:
           description: A comma-separated list of words to count as mentions. Defaults to
             username and @username.
         channel:
-          type: boolean
+          type: string
           description: Set to "true" to enable channel-wide notifications (@channel, @all,
             etc.), "false" to disable. Defaults to "true".
         first_name:
-          type: boolean
+          type: string
           description: Set to "true" to enable mentions for first name. Defaults to "true"
             if a first name is set, "false" otherwise.
     Timezone:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Modified notify_props to include only strings in documentation, not booleans.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/19840
