### PR TITLE
[MM-44488] Cloud limits: enforcing messages

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -371,6 +371,17 @@ components:
         has_next:
           type: boolean
           description: Whether there are more items after this page.
+        has_inaccessible_posts:
+          type: boolean
+          description: Whether there are inaccessible posts, past the cloud's plan limit.
+    PostWrapper:
+      type: object
+      properties:
+        post:
+          $ref: "#/components/schemas/Post"
+        is_inaccessible:
+          type: boolean
+          description: Whether the post is past the cloud plan's limit.
     PostListWithSearchMatches:
       type: object
       properties:

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -154,13 +154,22 @@
           schema:
             type: boolean
             default: false
+        - name: use_new
+          in: query
+          description: Use new response type(PostWrapper), which tells if the post is inaccessible due to cloud's plan limit.
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Post retrieval successful
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Post"
+                oneOf:
+                  - $ref: "#/components/schemas/Post"
+                  - $ref: "#/components/schemas/PostWrapper"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -863,6 +872,14 @@
 
         Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels` permission for the team.
       operationId: getPostsByIds
+      parameters:
+        - name: use_new
+          in: query
+          description: Use new response type(PostList), which tells if the post is inaccessible due to cloud's plan limit.
+          required: false
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           application/json:
@@ -878,9 +895,11 @@
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Post"
+                oneOf:
+                  - $ref: "#/components/schemas/PostList"
+                  - type: array
+                    items:
+                      $ref: "#/components/schemas/Post"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add optional param `use_new` to allow `getPost` and `getPostsByIDs` APIs to return new response types, which indicates if posts are inaccessible due to cloud plan's limit.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-44488
