### PR TITLE
Add gitpod.yml and put gitpod link in readme

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,7 @@ tasks:
       make run
   - name: Notice
     command: |
+      clear
       echo "Once the docs server is running, go to the following URL to view the docs:
 
       $(gp url 8080)"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+ports:
+  - port: 8080
+    onOpen: open-browser
+
+tasks:
+  - name: Docs
+    init: |
+      make build
+    command: |
+     make run

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,3 +8,9 @@ tasks:
       make build
     command: |
       make run
+  - name: Notice
+    command: |
+      echo "Once the docs server is running, go to the following URL to view the docs:
+
+      $(gp url 8080)"
+    openMode: split-right

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,4 +7,4 @@ tasks:
     init: |
       make build
     command: |
-     make run
+      make run

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To build the full YAML, run `make build` and it will be output to `html/static/m
 
 To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:8080`. For any updates to the source files, re-run the same commands.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mattermost/mattermost-api-reference)
+
 ## Deployment
 
 Deployment is handled automatically by our Jenkins CLI machine. When a pull request is merged it will automatically be deployed to [https://api.mattermost.com](https://api.mattermost.com).


### PR DESCRIPTION
This PR makes it so we can use Gitpod to spin up an environment to work on the API reference docs. This should be straightforward to add to other doc repos as well

Link to test this PR with gitpod https://gitpod.io/#https://github.com/mattermost/mattermost-api-reference/pull/708