### PR TITLE
[MM-44489] Cloud limits: enforcing files

### DIFF
--- a/v4/source/files.yaml
+++ b/v4/source/files.yaml
@@ -145,7 +145,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -184,7 +193,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -223,7 +241,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -274,7 +301,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -319,7 +355,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -363,7 +408,16 @@
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Do not have appropriate permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppError"
+          headers:
+            First-Inaccessible-File-Time:
+              schema:
+                type: integer
+              description: This header is included with the value "1" if the post is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":

--- a/v4/source/files.yaml
+++ b/v4/source/files.yaml
@@ -154,7 +154,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -202,7 +202,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -250,7 +250,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -310,7 +310,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -364,7 +364,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":
@@ -417,7 +417,7 @@
             First-Inaccessible-File-Time:
               schema:
                 type: integer
-              description: This header is included with the value "1" if the post is past the cloud's plan limit.
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
         "404":
           $ref: "#/components/responses/NotFound"
         "501":


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add `First-Inaccessible-File-Time` response-403-header for getFile APIs, which indicates if files are inaccessible due to the cloud plan's limit.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA - https://mattermost.atlassian.net/browse/MM-44489

Depends on this server PR - https://github.com/mattermost/mattermost-server/pull/20703
