### PR TITLE
Add missing operationId to trial-license/prev

### DIFF
--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -819,6 +819,7 @@
         ##### Permissions
 
         Must have `manage_systems` permissions.
+      operationId: GetLastTrialLicense
       responses:
         "200":
           description: License fetched successfully.


### PR DESCRIPTION
#### Summary
Adds missing `operationId` to `/trial-license/prev`.
Arbitrarily named `GetLastTrialLicense` based on summary and description.