### PR TITLE
fixing output GetKnownUsers to array

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -117,9 +117,10 @@ components:
         total_users_count:
           type: integer
     KnownUsers:
-        type: array
-          items:
-            type: string
+      type: array
+      properties:
+        items:
+          type: string
     Team:
       type: object
       properties:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -116,6 +116,10 @@ components:
       properties:
         total_users_count:
           type: integer
+    KnownUsers:
+        type: array
+          items:
+            type: string
     Team:
       type: object
       properties:

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -915,7 +915,8 @@
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsersStats"
+                type: array
+                $ref: "#/components/schemas/KnownUsers"
         "401":
           $ref: "#/components/responses/Unauthorized"
       x-code-samples:


### PR DESCRIPTION
### Summary
The documentation of GetKnownUsers showed an integer as the result. An array of userIds is returned by this comment.

#### Ticket Link
[issue](https://github.com/mattermost/mattermost-api-reference/issues/666)

