### PR TITLE
[MM-36280] add API docs for user's recent searches (GET, DELETE)

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -258,6 +258,81 @@ components:
             team_update_at:
               type: integer
               description: The time at which the team to which this channel belongs was last updated.
+    SearchParams:
+      type: object
+      properties:
+        excluded_date:
+          type: string
+          nullable: true
+        excluded_channels:
+          type: array
+          items:
+            type: string
+          nullable: true
+        after_date:
+          type: string
+          nullable: true
+        before_date:
+          type: string
+          nullable: true
+        on_date:
+          type: string
+          nullable: true
+        timezone_offset:
+          type: integer
+          nullable: true
+        from_users:
+          type: array
+          items:
+            type: string
+          nullable: true
+        excluded_before_date:
+          type: string
+          nullable: true
+        excluded_extensions:
+          type: array
+          items:
+            type: string
+          nullable: true
+        excluded_after_date:
+          type: string
+          nullable: true
+        extensions:
+          type: array
+          items:
+            type: string
+          nullable: true
+        or_terms:
+          type: boolean
+          nullable: true
+        search_without_userid:
+          type: boolean
+          nullable: true
+        modifier:
+          type: string
+          nullable: true
+        excluded_terms:
+          type: string
+          nullable: true
+        in_channels:
+          type: array
+          items:
+            type: string
+          nullable: true
+        excluded_users:
+          type: array
+          items:
+            type: string
+          nullable: true
+        terms:
+          type: string
+          nullable: true
+        ishashtag:
+          type: boolean
+          nullable: true
+        include_deleted_channels:
+          type: boolean
+          nullable: true
     ChannelData:
       type: object
       properties:

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -4538,7 +4538,86 @@
           source: |
             curl 'http://localhost:8065/api/v4/users/me/channel_members?page=0&per_page=2' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
+  "/users/{user_id}/recent_searches":
+    get:
+      tags:
+        - users
+      summary: Get recent searches from all teams for a user
+      description: |
+        Get the 5 most recent searches that the user performed.
 
+        __Minimum server version__: 7.0.0
+
+        ##### Permissions
+        Must be logged in.
+      operationId: getRecentSearches
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user. This can also be "me" which will point to the current user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User's recent searches retrieval successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SearchParams"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl 'http://localhost:8065/api/v4/users/me/recent_searches' \
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'
+    delete:
+      tags:
+        - users
+      summary: Remove recent searches from all teams for a user
+      description: |
+        Remove all the recent searches duplicates that match a given search parameter.
+
+        __Minimum server version__: 7.6.0
+
+        ##### Permissions
+        Must be logged in.
+      operationId: deleteRecentSearch
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user. This can also be "me" which will point to the current user.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The search parameter to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchParams'
+      responses:
+        "200":
+          description: User's recent searches removal successful
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl -X DELETE 'http://localhost:8065/api/v4/users/me/recent_searches' \
+            -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'
   /users/migrate_auth/ldap:
     post:
       tags:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add missing API doc for `GET /users/:id/recent_searches` and `DELETE /users/:id/recent_searches`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA ticket: https://mattermost.atlassian.net/browse/MM-36280
