### PR TITLE
last_post_at timestamp should be int64

### DIFF
--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -94,9 +94,9 @@ components:
         props:
           type: object
         last_password_update:
-          type: integer
+          type: int64
         last_picture_update:
-          type: integer
+          type: int64
         failed_attempts:
           type: integer
         mfa_active:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -206,6 +206,7 @@ components:
         last_post_at:
           description: The time in milliseconds of the last post of a channel
           type: integer
+          format: int64
         total_msg_count:
           type: integer
         extra_update_at:

--- a/v4/source/definitions.yaml
+++ b/v4/source/definitions.yaml
@@ -94,9 +94,11 @@ components:
         props:
           type: object
         last_password_update:
-          type: int64
+          type: integer
+          format: int64
         last_picture_update:
-          type: int64
+          type: integer
+          format: int64
         failed_attempts:
           type: integer
         mfa_active:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The `last_post_at` field under `Channel` is a timestamp. Therefore, it should be formatted as `int64`.

EDIT: Also fixed `last_password_update` and `last_picture_update` as [suggested below](https://github.com/mattermost/mattermost-api-reference/pull/728#pullrequestreview-1437032048)
<!--
A description of what this pull request does.
-->

#### Ticket Link

Fixes #727
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

