### PR TITLE
Playbook API documentation reference updated to mattermost-server repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All documentation is available under the terms of a [Creative Commons License](h
 We're accepting pull requests! See something that could be documented better or is missing documentation? Make a PR and we'll gladly accept it.
 
 All the documentation is written in YAML and found in the [v4/source](https://github.com/mattermost/mattermost-api-reference/tree/master/v4/source) directories. APIv4 documentation is in the [v4 directory](https://github.com/mattermost/mattermost-api-reference/tree/master/v4).
-APIs for [Playbooks](https://github.com/mattermost/mattermost-plugin-playbooks) are retrieved from GitHub at build time and integrated into the final YAML file.
+APIs for [Playbooks](https://github.com/mattermost/mattermost-server/blob/master/server/playbooks/server/api/api.yaml) are retrieved from GitHub at build time and integrated into the final YAML file.
 
 * When adding a new route, please add it to the correct file. For example, a channel route will go in [channels.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/channels.yaml).
 * To add a new tag, please do so in [introduction.yaml](https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/introduction.yaml)


### PR DESCRIPTION
#### Summary
Contributor notes reference previous repository structure. Links have been updated to point future contributors to the new location for playbook API documentation in mattermost-server mono-repo. 

#### Ticket Link
Follow on PR to contributor guideline changes as a result of https://github.com/mattermost/mattermost-api-reference/pull/730