### PR TITLE
Absolute paths in API Spec

### DIFF
--- a/v4/source/actions.yaml
+++ b/v4/source/actions.yaml
@@ -1,4 +1,4 @@
-  /actions/dialogs/open:
+  /api/v4/actions/dialogs/open:
     post:
       tags:
         - integration_actions
@@ -71,7 +71,7 @@
                 $ref: "#/components/schemas/StatusOK"
         "400":
           $ref: "#/components/responses/BadRequest"
-  /actions/dialogs/submit:
+  /api/v4/actions/dialogs/submit:
     post:
       tags:
         - integration_actions

--- a/v4/source/bleve.yaml
+++ b/v4/source/bleve.yaml
@@ -1,4 +1,4 @@
-  /bleve/purge_indexes:
+  /api/v4/bleve/purge_indexes:
     post:
       tags:
         - bleve

--- a/v4/source/bots.yaml
+++ b/v4/source/bots.yaml
@@ -1,4 +1,4 @@
-  /bots:
+  /api/v4/bots:
     post:
       tags:
         - bots
@@ -146,7 +146,7 @@
             if ($resp->getStatusCode() == 200) {
                 $bots = json_decode($resp->getBody());
             }
-  "/bots/{bot_user_id}":
+  "/api/v4/bots/{bot_user_id}":
     put:
       tags:
         - bots
@@ -292,7 +292,7 @@
             if ($resp->getStatusCode() == 200) {
                 $bot = json_decode($resp->getBody());
             }
-  "/bots/{bot_user_id}/disable":
+  "/api/v4/bots/{bot_user_id}/disable":
     post:
       tags:
         - bots
@@ -348,7 +348,7 @@
             if ($resp->getStatusCode() == 200) {
                 $disabledBot = json_decode($resp->getBody());
             }
-  "/bots/{bot_user_id}/enable":
+  "/api/v4/bots/{bot_user_id}/enable":
     post:
       tags:
         - bots
@@ -404,7 +404,7 @@
             if ($resp->getStatusCode() == 200) {
                 $enabledBot = json_decode($resp->getBody());
             }
-  "/bots/{bot_user_id}/assign/{user_id}":
+  "/api/v4/bots/{bot_user_id}/assign/{user_id}":
     post:
       tags:
         - bots
@@ -467,7 +467,7 @@
             if ($resp->getStatusCode() == 200) {
                 $assignedBot = json_decode($resp->getBody());
             }
-  "/bots/{bot_user_id}/icon":
+  "/api/v4/bots/{bot_user_id}/icon":
     get:
       tags:
         - bots
@@ -714,7 +714,7 @@
               if ($resp->getStatusCode() == 200) {
                   $ok = json_decode($resp->getBody())->status;
               }
-  "/bots/{bot_user_id}/convert_to_user":
+  "/api/v4/bots/{bot_user_id}/convert_to_user":
     post:
       tags:
         - bots

--- a/v4/source/brand.yaml
+++ b/v4/source/brand.yaml
@@ -1,4 +1,4 @@
-  /brand/image:
+  /api/v4/brand/image:
     get:
       tags:
         - brand

--- a/v4/source/channels.yaml
+++ b/v4/source/channels.yaml
@@ -1,4 +1,4 @@
-  /channels:
+  /api/v4/channels:
     get:
       tags:
         - channels
@@ -140,7 +140,7 @@
             // CreateChannel
 
             rchannel, resp := Client.CreateChannel(channel)
-  /channels/direct:
+  /api/v4/channels/direct:
     post:
       tags:
         - channels
@@ -185,7 +185,7 @@
 
             // CreateDirectChannel
             dm, resp := Client.CreateDirectChannel(<ID OF User1>, <ID OF User2>)
-  /channels/group:
+  /api/v4/channels/group:
     post:
       tags:
         - channels
@@ -231,7 +231,7 @@
 
             // CreateGroupChannel
             rgc, resp := Client.CreateGroupChannel(userIds)
-  /channels/search:
+  /api/v4/channels/search:
     post:
       tags:
         - channels
@@ -381,7 +381,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  /channels/group/search:
+  /api/v4/channels/group/search:
     post:
       tags:
         - channels
@@ -431,7 +431,7 @@
 
             // SearchGroupChannels
             channels, resp := Client.SearchGroupChannels(search)
-  "/teams/{team_id}/channels/ids":
+  "/api/v4/teams/{team_id}/channels/ids":
     post:
       tags:
         - channels
@@ -488,7 +488,7 @@
             // GetPublicChannelsByIdsForTeam
 
             channels, resp := Client.GetPublicChannelsByIdsForTeam(<TEAMID>, channelIds)
-  "/channels/{channel_id}/timezones":
+  "/api/v4/channels/{channel_id}/timezones":
     get:
       tags:
         - channels
@@ -532,7 +532,7 @@
 
             // GetChannelStats
             stats, resp := Client.GetChannelTimezones(<CHANNELID>)
-  "/channels/{channel_id}":
+  "/api/v4/channels/{channel_id}":
     get:
       tags:
         - channels
@@ -698,7 +698,7 @@
 
             // DeleteChannel
             pass, resp := Client.DeleteChannel(<CHANNELID>)
-  "/channels/{channel_id}/patch":
+  "/api/v4/channels/{channel_id}/patch":
     put:
       tags:
         - channels
@@ -777,7 +777,7 @@
 
             // PatchChannel
             channel, resp := Client.PatchChannel(<CHANNELID>, patch)
-  "/channels/{channel_id}/privacy":
+  "/api/v4/channels/{channel_id}/privacy":
     put:
       tags:
         - channels
@@ -849,7 +849,7 @@
             // Update channel's privacy to Private
 
             updatedChannel, resp := Client.UpdateChannelPrivacy(<CHANNELID>, model.CHANNEL_PRIVATE)
-  "/channels/{channel_id}/restore":
+  "/api/v4/channels/{channel_id}/restore":
     post:
       tags:
         - channels
@@ -882,7 +882,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/channels/{channel_id}/move":
+  "/api/v4/channels/{channel_id}/move":
     post:
       tags:
         - channels
@@ -932,7 +932,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/channels/{channel_id}/stats":
+  "/api/v4/channels/{channel_id}/stats":
     get:
       tags:
         - channels
@@ -971,7 +971,7 @@
 
             // GetChannelStats
             stats, resp := Client.GetChannelStats(<CHANNELID>)
-  "/channels/{channel_id}/pinned":
+  "/api/v4/channels/{channel_id}/pinned":
     get:
       tags:
         - channels
@@ -1007,7 +1007,7 @@
 
             // GetPinnedPosts
             posts, resp := Client.GetPinnedPosts(<CHANNELID>, "")
-  "/teams/{team_id}/channels":
+  "/api/v4/teams/{team_id}/channels":
     get:
       tags:
         - channels
@@ -1068,7 +1068,7 @@
             // GetPublicChannelsForTeam
 
             channels, resp := Client.GetPublicChannelsForTeam(<TEAMID>, 0, 100, "")
-  "/teams/{team_id}/channels/private":
+  "/api/v4/teams/{team_id}/channels/private":
     get:
       tags:
         - channels
@@ -1130,7 +1130,7 @@
             // GetPrivateChannelsForTeam
 
             channels, resp := Client.GetPrivateChannelsForTeam(<TEAMID>, 0, 100, "")
-  "/teams/{team_id}/channels/deleted":
+  "/api/v4/teams/{team_id}/channels/deleted":
     get:
       tags:
         - channels
@@ -1178,7 +1178,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/teams/{team_id}/channels/autocomplete":
+  "/api/v4/teams/{team_id}/channels/autocomplete":
     get:
       tags:
         - channels
@@ -1225,7 +1225,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/teams/{team_id}/channels/search_autocomplete":
+  "/api/v4/teams/{team_id}/channels/search_autocomplete":
     get:
       tags:
         - channels
@@ -1272,7 +1272,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/teams/{team_id}/channels/search":
+  "/api/v4/teams/{team_id}/channels/search":
     post:
       tags:
         - channels
@@ -1337,7 +1337,7 @@
 
             // SearchChannels
             channels, resp := Client.SearchChannels(<TEAMID>, search)
-  "/teams/{team_id}/channels/search_archived":
+  "/api/v4/teams/{team_id}/channels/search_archived":
     post:
       tags:
         - channels
@@ -1406,7 +1406,7 @@
 
             // SearchChannels
             channels, resp := Client.SearchArchivedChannels(<TEAMID>, search)
-  "/teams/{team_id}/channels/name/{channel_name}":
+  "/api/v4/teams/{team_id}/channels/name/{channel_name}":
     get:
       tags:
         - channels
@@ -1461,7 +1461,7 @@
             // GetChannelByName
 
             channel, resp := Client.GetChannelByName(<CHANNEL NAME>, <TEAMID>, "")
-  "/teams/name/{team_name}/channels/name/{channel_name}":
+  "/api/v4/teams/name/{team_name}/channels/name/{channel_name}":
     get:
       tags:
         - channels
@@ -1516,7 +1516,7 @@
             // GetChannelByNameForTeamName
 
             channel, resp = Client.GetChannelByNameForTeamName(<CHANNEL NAME>, <TEAM NAME>, "")
-  "/channels/{channel_id}/members":
+  "/api/v4/channels/{channel_id}/members":
     get:
       tags:
         - channels
@@ -1633,7 +1633,7 @@
             // AddChannelMemberWithRootId
 
             cm, resp := Client.AddChannelMemberWithRootId(<CHANNEL ID>, <ID OF USER TO ADD>, <POST ROOT ID>)
-  "/channels/{channel_id}/members/ids":
+  "/api/v4/channels/{channel_id}/members/ids":
     post:
       tags:
         - channels
@@ -1687,7 +1687,7 @@
 
             // GetChannelMembersByIds
             cm, resp := Client.GetChannelMembersByIds(<CHANNELID>, usersIds)
-  "/channels/{channel_id}/members/{user_id}":
+  "/api/v4/channels/{channel_id}/members/{user_id}":
     get:
       tags:
         - channels
@@ -1783,7 +1783,7 @@
 
             // RemoveUserFromChannel
             pass, resp := Client.RemoveUserFromChannel(<CHANNELID>, <USERID>)
-  "/channels/{channel_id}/members/{user_id}/roles":
+  "/api/v4/channels/{channel_id}/members/{user_id}/roles":
     put:
       tags:
         - channels
@@ -1844,7 +1844,7 @@
             // UpdateChannelRoles
 
             pass, resp := Client.UpdateChannelRoles(<CHANNELID>, <USERIDTOPROMOTE>, "channel_admin channel_user")
-  "/channels/{channel_id}/members/{user_id}/schemeRoles":
+  "/api/v4/channels/{channel_id}/members/{user_id}/schemeRoles":
     put:
       tags:
         - channels
@@ -1904,7 +1904,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/channels/{channel_id}/members/{user_id}/notify_props":
+  "/api/v4/channels/{channel_id}/members/{user_id}/notify_props":
     put:
       tags:
         - channels
@@ -1971,7 +1971,7 @@
             // UpdateChannelNotifyProps
 
             pass, resp := Client.UpdateChannelNotifyProps(<CHANNELID>, <USERID>, props)
-  "/channels/members/{user_id}/view":
+  "/api/v4/channels/members/{user_id}/view":
     post:
       tags:
         - channels
@@ -2046,7 +2046,7 @@
             }
             // ViewChannel
             pass, resp := Client.ViewChannel(<USERID>, view)
-  "/users/{user_id}/teams/{team_id}/channels/members":
+  "/api/v4/users/{user_id}/teams/{team_id}/channels/members":
     get:
       tags:
         - channels
@@ -2100,7 +2100,7 @@
             // GetChannelMembersForUser
 
             members, resp := Client.GetChannelMembersForUser(<USERID>, <TEAMID>, "")
-  "/users/{user_id}/teams/{team_id}/channels":
+  "/api/v4/users/{user_id}/teams/{team_id}/channels":
     get:
       tags:
         - channels
@@ -2167,7 +2167,7 @@
             // GetChannelsForTeamForUser
 
             channels, resp := Client.GetChannelsForTeamForUser(<TEAMID>, <USERID>, "")
-  "/users/{user_id}/channels":
+  "/api/v4/users/{user_id}/channels":
     get:
       tags:
         - channels
@@ -2232,7 +2232,7 @@
           source: |
             curl -X GET 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/channels' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'
-  "/users/{user_id}/channels/{channel_id}/unread":
+  "/api/v4/users/{user_id}/channels/{channel_id}/unread":
     get:
       tags:
         - channels
@@ -2285,7 +2285,7 @@
             // GetChannelUnread
 
             channelUnread, resp := Client.GetChannelUnread(<CHANNELID>, <USERID>)
-  "/channels/{channel_id}/scheme":
+  "/api/v4/channels/{channel_id}/scheme":
     put:
       tags:
         - channels
@@ -2354,7 +2354,7 @@
               -H 'Authorization: Bearer frn8fu5rtpyc5m4xy6q3oj4yur' \
               -H 'Content-Type: application/json' \
               -d '{"scheme_id": "qjda3stwafbgpqjaxej3k76sga"}'
-  "/channels/{channel_id}/members_minus_group_members":
+  "/api/v4/channels/{channel_id}/members_minus_group_members":
     get:
       tags:
         - channels
@@ -2419,7 +2419,7 @@
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json' \
               -H 'X-Requested-With: XMLHttpRequest'
-  "/channels/{channel_id}/member_counts_by_group":
+  "/api/v4/channels/{channel_id}/member_counts_by_group":
     get:
       tags:
         - channels
@@ -2463,7 +2463,7 @@
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \
               -H 'Content-Type: application/json' \
               -H 'X-Requested-With: XMLHttpRequest'
-  "/channels/{channel_id}/moderations":
+  "/api/v4/channels/{channel_id}/moderations":
     get:
       tags:
         - channels
@@ -2498,7 +2498,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/channels/{channel_id}/moderations/patch":
+  "/api/v4/channels/{channel_id}/moderations/patch":
     put:
       tags:
         - channels
@@ -2541,7 +2541,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/teams/{team_id}/channels/categories":
+  "/api/v4/users/{user_id}/teams/{team_id}/channels/categories":
     get:
       tags:
         - channels
@@ -2683,7 +2683,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/users/{user_id}/teams/{team_id}/channels/categories/order":
+  "/api/v4/users/{user_id}/teams/{team_id}/channels/categories/order":
     get:
       tags:
         - channels
@@ -2780,7 +2780,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/users/{user_id}/teams/{team_id}/channels/categories/{category_id}":
+  "/api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}":
     get:
       tags:
         - channels

--- a/v4/source/cloud.yaml
+++ b/v4/source/cloud.yaml
@@ -1,4 +1,4 @@
-  /cloud/limits:
+  /api/v4/cloud/limits:
     get:
       tags:
         - cloud
@@ -26,7 +26,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/products:
+  /api/v4/cloud/products:
     get:
       tags:
         - cloud
@@ -58,7 +58,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/payment:
+  /api/v4/cloud/payment:
     post:
       tags:
         - cloud
@@ -89,7 +89,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/payment/confirm:
+  /api/v4/cloud/payment/confirm:
     post:
       tags:
         - cloud
@@ -123,7 +123,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/customer:
+  /api/v4/cloud/customer:
     get:
       tags:
         - cloud
@@ -200,7 +200,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/customer/address:
+  /api/v4/cloud/customer/address:
     put:
       tags:
         - cloud
@@ -237,7 +237,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/subscription:
+  /api/v4/cloud/subscription:
     get:
       tags:
         - cloud
@@ -267,7 +267,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/subscription/invoices:
+  /api/v4/cloud/subscription/invoices:
     get:
       tags:
         - cloud
@@ -299,7 +299,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/subscription/invoices/{invoice_id}/pdf:
+  /api/v4/cloud/subscription/invoices/{invoice_id}/pdf:
     get:
       tags:
         - cloud
@@ -330,7 +330,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /cloud/webhook:
+  /api/v4/cloud/webhook:
     post:
       tags:
         - cloud

--- a/v4/source/cluster.yaml
+++ b/v4/source/cluster.yaml
@@ -1,4 +1,4 @@
-  /cluster/status:
+  /api/v4/cluster/status:
     get:
       tags:
         - cluster

--- a/v4/source/commands.yaml
+++ b/v4/source/commands.yaml
@@ -1,4 +1,4 @@
-  /commands:
+  /api/v4/commands:
     post:
       tags:
         - commands
@@ -127,7 +127,7 @@
             // The second parameter is to set if you want only custom commands (true) or defaults commands (false)
 
             listCommands, resp := Client.ListCommands(<TEAMID>, true)
-  "/teams/{team_id}/commands/autocomplete":
+  "/api/v4/teams/{team_id}/commands/autocomplete":
     get:
       tags:
         - commands
@@ -220,7 +220,7 @@
             teamID := "4xp9fdt77pncbef59f4k1qe83o"
             userInput := "/jira"
             listCommands, resp := Client.ListCommandAutocompleteSuggestions(userInput, teamID)
-  "/commands/{command_id}":
+  "/api/v4/commands/{command_id}":
     get:
       tags:
         - commands
@@ -363,7 +363,7 @@
 
             // DeleteCommand
             ok, resp := Client.DeleteCommand(<COMMANDID>)
-  "/commands/{command_id}/move":
+  "/api/v4/commands/{command_id}/move":
     put:
       tags:
         - commands
@@ -420,7 +420,7 @@
 
             // MoveCommand
             ok, resp := Client.MoveCommand(<TEAMID>,<COMMANDID>)
-  "/commands/{command_id}/regen_token":
+  "/api/v4/commands/{command_id}/regen_token":
     put:
       tags:
         - commands
@@ -466,7 +466,7 @@
 
             // RegenCommandToken
             newToken, resp := Client.RegenCommandToken(<COMMANDID>)
-  /commands/execute:
+  /api/v4/commands/execute:
     post:
       tags:
         - commands

--- a/v4/source/compliance.yaml
+++ b/v4/source/compliance.yaml
@@ -1,4 +1,4 @@
-  /compliance/reports:
+  /api/v4/compliance/reports:
     post:
       tags:
         - compliance
@@ -65,7 +65,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/compliance/reports/{report_id}":
+  "/api/v4/compliance/reports/{report_id}":
     get:
       tags:
         - compliance
@@ -97,7 +97,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/compliance/reports/{report_id}/download":
+  "/api/v4/compliance/reports/{report_id}/download":
     get:
       tags:
         - compliance

--- a/v4/source/dataretention.yaml
+++ b/v4/source/dataretention.yaml
@@ -1,4 +1,4 @@
-  /data_retention/policy:
+  /api/v4/data_retention/policy:
     get:
       tags:
         - data retention
@@ -31,7 +31,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /data_retention/policies_count:
+  /api/v4/data_retention/policies_count:
     get:
       tags:
         - data retention
@@ -67,7 +67,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /data_retention/policies:
+  /api/v4/data_retention/policies:
     get:
       tags:
         - data retention
@@ -151,7 +151,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/data_retention/policies/{policy_id}":
+  "/api/v4/data_retention/policies/{policy_id}":
     get:
       tags:
         - data retention
@@ -270,7 +270,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"  
-  "/data_retention/policies/{policy_id}/teams":
+  "/api/v4/data_retention/policies/{policy_id}/teams":
     get:
       tags:
         - data retention
@@ -414,7 +414,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/data_retention/policies/{policy_id}/teams/search":
+  "/api/v4/data_retention/policies/{policy_id}/teams/search":
     post:
       tags:
         - data retention
@@ -464,7 +464,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/data_retention/policies/{policy_id}/channels":
+  "/api/v4/data_retention/policies/{policy_id}/channels":
     get:
       tags:
         - data retention
@@ -606,7 +606,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/data_retention/policies/{policy_id}/channels/search":
+  "/api/v4/data_retention/policies/{policy_id}/channels/search":
     post:
       tags:
         - data retention

--- a/v4/source/elasticsearch.yaml
+++ b/v4/source/elasticsearch.yaml
@@ -1,4 +1,4 @@
-  /elasticsearch/test:
+  /api/v4/elasticsearch/test:
     post:
       tags:
         - elasticsearch
@@ -31,7 +31,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /elasticsearch/purge_indexes:
+  /api/v4/elasticsearch/purge_indexes:
     post:
       tags:
         - elasticsearch

--- a/v4/source/emoji.yaml
+++ b/v4/source/emoji.yaml
@@ -1,4 +1,4 @@
-  /emoji:
+  /api/v4/emoji:
     post:
       tags:
         - emoji
@@ -90,7 +90,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/emoji/{emoji_id}":
+  "/api/v4/emoji/{emoji_id}":
     get:
       tags:
         - emoji
@@ -155,7 +155,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/emoji/name/{emoji_name}":
+  "/api/v4/emoji/name/{emoji_name}":
     get:
       tags:
         - emoji
@@ -189,7 +189,7 @@
           $ref: "#/components/responses/NotFound"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/emoji/{emoji_id}/image":
+  "/api/v4/emoji/{emoji_id}/image":
     get:
       tags:
         - emoji
@@ -219,7 +219,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /emoji/search:
+  /api/v4/emoji/search:
     post:
       tags:
         - emoji
@@ -268,7 +268,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /emoji/autocomplete:
+  /api/v4/emoji/autocomplete:
     get:
       tags:
         - emoji

--- a/v4/source/exports.yaml
+++ b/v4/source/exports.yaml
@@ -1,4 +1,4 @@
-  "/exports":
+  "/api/v4/exports":
     get:
       tags:
         - exports
@@ -33,7 +33,7 @@
           source: |
             curl 'http://localhost:8065/api/v4/exports' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'
-  "/exports/{export_name}":
+  "/api/v4/exports/{export_name}":
     get:
       tags:
         - exports

--- a/v4/source/files.yaml
+++ b/v4/source/files.yaml
@@ -1,4 +1,4 @@
-  /files:
+  /api/v4/files:
     post:
       tags:
         - files
@@ -122,7 +122,7 @@
             -F 'channel_id=CHANNEL_ID' \
             --header 'authorization: Bearer c49adc55z3f53ck7xtp8ebq1ir'
             https://your-mattermost-url.com/api/v4/files
-  "/files/{file_id}":
+  "/api/v4/files/{file_id}":
     get:
       tags:
         - files
@@ -170,7 +170,7 @@
             fileID := "4xp9fdt77pncbef59f4k1qe83o"
 
             data, resp := Client.GetFile(fileID)
-  "/files/{file_id}/thumbnail":
+  "/api/v4/files/{file_id}/thumbnail":
     get:
       tags:
         - files
@@ -218,7 +218,7 @@
             fileID := "4xp9fdt77pncbef59f4k1qe83o"
 
             data, resp := Client.GetFileThumbnail(fileID)
-  "/files/{file_id}/preview":
+  "/api/v4/files/{file_id}/preview":
     get:
       tags:
         - files
@@ -266,7 +266,7 @@
             fileID := "4xp9fdt77pncbef59f4k1qe83o"
 
             data, resp := Client.GetFilePreview(fileID)
-  "/files/{file_id}/link":
+  "/api/v4/files/{file_id}/link":
     get:
       tags:
         - files
@@ -326,7 +326,7 @@
             fileID := "4xp9fdt77pncbef59f4k1qe83o"
 
             data, resp := Client.GetFileLink(fileID)
-  "/files/{file_id}/info":
+  "/api/v4/files/{file_id}/info":
     get:
       tags:
         - files
@@ -380,7 +380,7 @@
             fileID := "4xp9fdt77pncbef59f4k1qe83o"
 
             info, resp := Client.GetFileInfo(fileID)
-  "/files/{file_id}/public":
+  "/api/v4/files/{file_id}/public":
     get:
       tags:
         - files
@@ -423,7 +423,7 @@
         "501":
           $ref: "#/components/responses/NotImplemented"
 
-  "/teams/{team_id}/files/search":
+  "/api/v4/teams/{team_id}/files/search":
     post:
       tags:
         - teams

--- a/v4/source/groups.yaml
+++ b/v4/source/groups.yaml
@@ -1,4 +1,4 @@
-  /groups:
+  /api/v4/groups:
     get:
       tags:
         - groups
@@ -153,7 +153,7 @@
           description: Group creation and memberships successful.
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/groups/{group_id}":
+  "/api/v4/groups/{group_id}":
     get:
       tags:
         - groups
@@ -220,7 +220,7 @@
             application/json:
               schema:
                 $ref: "#/components/schemas/StatusOK"
-  "/groups/{group_id}/patch":
+  "/api/v4/groups/{group_id}/patch":
     put:
       tags:
         - groups
@@ -275,7 +275,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/teams/{team_id}/link":
+  "/api/v4/groups/{group_id}/teams/{team_id}/link":
     post:
       tags:
         - groups
@@ -354,7 +354,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/channels/{channel_id}/link":
+  "/api/v4/groups/{group_id}/channels/{channel_id}/link":
     post:
       tags:
         - groups
@@ -443,7 +443,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/teams/{team_id}":
+  "/api/v4/groups/{group_id}/teams/{team_id}":
     get:
       tags:
         - groups
@@ -485,7 +485,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/channels/{channel_id}":
+  "/api/v4/groups/{group_id}/channels/{channel_id}":
     get:
       tags:
         - groups
@@ -527,7 +527,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/teams":
+  "/api/v4/groups/{group_id}/teams":
     get:
       tags:
         - groups
@@ -565,7 +565,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/channels":
+  "/api/v4/groups/{group_id}/channels":
     get:
       tags:
         - groups
@@ -603,7 +603,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/teams/{team_id}/patch":
+  "/api/v4/groups/{group_id}/teams/{team_id}/patch":
     put:
       tags:
         - groups
@@ -661,7 +661,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/channels/{channel_id}/patch":
+  "/api/v4/groups/{group_id}/channels/{channel_id}/patch":
     put:
       tags:
         - groups
@@ -718,7 +718,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/groups/{group_id}/members":
+  "/api/v4/groups/{group_id}/members":
     get:
       tags:
         - groups
@@ -862,7 +862,7 @@
             application/json:
               schema:
                 $ref: "#/components/schemas/StatusOK"
-  "/groups/{group_id}/stats":
+  "/api/v4/groups/{group_id}/stats":
     get:
       tags:
         - groups
@@ -904,7 +904,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/channels/{channel_id}/groups":
+  "/api/v4/channels/{channel_id}/groups":
     get:
       tags:
         - groups
@@ -961,7 +961,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/teams/{team_id}/groups":
+  "/api/v4/teams/{team_id}/groups":
     get:
       tags:
         - groups
@@ -1015,7 +1015,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/teams/{team_id}/groups_by_channels":
+  "/api/v4/teams/{team_id}/groups_by_channels":
       get:
         tags:
           - groups
@@ -1078,7 +1078,7 @@
             $ref: "#/components/responses/InternalServerError"
           "501":
             $ref: "#/components/responses/NotImplemented"
-  "/users/{user_id}/groups":
+  "/api/v4/users/{user_id}/groups":
     get:
       tags:
         - groups

--- a/v4/source/imports.yaml
+++ b/v4/source/imports.yaml
@@ -1,4 +1,4 @@
-  "/imports":
+  "/api/v4/imports":
     get:
       tags:
         - imports

--- a/v4/source/insights.yaml
+++ b/v4/source/insights.yaml
@@ -1,4 +1,4 @@
-  /teams/{team_id}/top/reactions:
+  /api/v4/teams/{team_id}/top/reactions:
     get:
       tags:
         - insights
@@ -52,7 +52,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/me/top/reactions:
+  /api/v4/users/me/top/reactions:
     get:
       tags:
         - insights
@@ -111,7 +111,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /teams/{team_id}/top/channels:
+  /api/v4/teams/{team_id}/top/channels:
     get:
       tags:
         - insights
@@ -165,7 +165,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/me/top/channels:
+  /api/v4/users/me/top/channels:
     get:
       tags:
         - insights
@@ -223,7 +223,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /teams/{team_id}/top/team_members:
+  /api/v4/teams/{team_id}/top/team_members:
     get:
       tags:
         - insights
@@ -277,7 +277,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /teams/{team_id}/top/threads:
+  /api/v4/teams/{team_id}/top/threads:
     get:
       tags:
         - insights
@@ -331,7 +331,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/me/top/threads:
+  /api/v4/users/me/top/threads:
     get:
       tags:
         - insights
@@ -389,7 +389,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/me/top/dms:
+  /api/v4/users/me/top/dms:
     get:
       tags:
         - insights

--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -642,6 +642,6 @@ x-tagGroups:
       - exports
       - usage
 servers:
-  - url: http://your-mattermost-url.com/api/v4
-  - url: https://your-mattermost-url.com/api/v4
+  - url: http://your-mattermost-url.com
+  - url: https://your-mattermost-url.com
 paths:

--- a/v4/source/jobs.yaml
+++ b/v4/source/jobs.yaml
@@ -1,4 +1,4 @@
-  /jobs:
+  /api/v4/jobs:
     get:
       tags:
         - jobs
@@ -81,7 +81,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/jobs/{job_id}":
+  "/api/v4/jobs/{job_id}":
     get:
       tags:
         - jobs
@@ -114,7 +114,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/jobs/{job_id}/download":
+  "/api/v4/jobs/{job_id}/download":
     get:
       tags:
         - jobs
@@ -141,7 +141,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/jobs/{job_id}/cancel":
+  "/api/v4/jobs/{job_id}/cancel":
     post:
       tags:
         - jobs
@@ -174,7 +174,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/jobs/type/{type}":
+  "/api/v4/jobs/type/{type}":
     get:
       tags:
         - jobs

--- a/v4/source/ldap.yaml
+++ b/v4/source/ldap.yaml
@@ -1,4 +1,4 @@
-  /ldap/sync:
+  /api/v4/ldap/sync:
     post:
       tags:
         - LDAP
@@ -20,7 +20,7 @@
                 $ref: "#/components/schemas/StatusOK"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /ldap/test:
+  /api/v4/ldap/test:
     post:
       tags:
         - LDAP
@@ -44,7 +44,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /ldap/groups:
+  /api/v4/ldap/groups:
     get:
       tags:
         - ldap
@@ -91,7 +91,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /ldap/groups/{remote_id}/link:
+  /api/v4/ldap/groups/{remote_id}/link:
     post:
       tags:
         - ldap
@@ -154,7 +154,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /ldap/migrateid:
+  /api/v4/ldap/migrateid:
     post:
       tags:
         - LDAP
@@ -197,7 +197,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /ldap/certificate/public:
+  /api/v4/ldap/certificate/public:
     post:
       tags:
         - LDAP
@@ -261,7 +261,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /ldap/certificate/private:
+  /api/v4/ldap/certificate/private:
     post:
       tags:
         - LDAP

--- a/v4/source/oauth.yaml
+++ b/v4/source/oauth.yaml
@@ -1,4 +1,4 @@
-  /oauth/apps:
+  /api/v4/oauth/apps:
     post:
       tags:
         - OAuth
@@ -100,7 +100,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/oauth/apps/{app_id}":
+  "/api/v4/oauth/apps/{app_id}":
     get:
       tags:
         - OAuth
@@ -264,7 +264,7 @@
           $ref: "#/components/responses/NotFound"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/oauth/apps/{app_id}/regen_secret":
+  "/api/v4/oauth/apps/{app_id}/regen_secret":
     post:
       tags:
         - OAuth
@@ -301,7 +301,7 @@
           $ref: "#/components/responses/NotFound"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/oauth/apps/{app_id}/info":
+  "/api/v4/oauth/apps/{app_id}/info":
     get:
       tags:
         - OAuth
@@ -336,7 +336,7 @@
           $ref: "#/components/responses/NotFound"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/users/{user_id}/oauth/apps/authorized":
+  "/api/v4/users/{user_id}/oauth/apps/authorized":
     get:
       tags:
         - OAuth

--- a/v4/source/opengraph.yaml
+++ b/v4/source/opengraph.yaml
@@ -1,4 +1,4 @@
-  /opengraph:
+  /api/v4/opengraph:
     post:
       tags:
         - OpenGraph

--- a/v4/source/permissions.yaml
+++ b/v4/source/permissions.yaml
@@ -1,4 +1,4 @@
-  /permissions/ancillary:
+  /api/v4/permissions/ancillary:
     get:
       tags:
         - permissions

--- a/v4/source/plugins.yaml
+++ b/v4/source/plugins.yaml
@@ -1,4 +1,4 @@
-  /plugins:
+  /api/v4/plugins:
     post:
       tags:
         - plugins
@@ -130,7 +130,7 @@
             Client.Login("email@domain.com", "Password1")
 
             pluginsResp, resp := Client.GetPlugins()
-  /plugins/install_from_url:
+  /api/v4/plugins/install_from_url:
     post:
       tags:
         - plugins
@@ -191,7 +191,7 @@
 
             // Forced
             manifest, resp := Client.InstallPluginFromUrl(url, true)
-  "/plugins/{plugin_id}":
+  "/api/v4/plugins/{plugin_id}":
     delete:
       tags:
         - plugins
@@ -243,7 +243,7 @@
             pluginID := "com.mattermost.demo-plugin"
 
             ok, resp = Client.RemovePlugin(pluginID)
-  "/plugins/{plugin_id}/enable":
+  "/api/v4/plugins/{plugin_id}/enable":
     post:
       tags:
         - plugins
@@ -295,7 +295,7 @@
             pluginID := "com.mattermost.demo-plugin"
 
             ok, resp = Client.EnablePlugin(pluginID)
-  "/plugins/{plugin_id}/disable":
+  "/api/v4/plugins/{plugin_id}/disable":
     post:
       tags:
         - plugins
@@ -347,7 +347,7 @@
             pluginID := "com.mattermost.demo-plugin"
 
             ok, resp = Client.DisablePlugin(pluginID)
-  /plugins/webapp:
+  /api/v4/plugins/webapp:
     get:
       tags:
         - plugins
@@ -385,7 +385,7 @@
             Client := model.NewAPIv4Client("https://your-mattermost-url.com")
 
             manifests, resp := Client.GetWebappPlugins()
-  /plugins/statuses:
+  /api/v4/plugins/statuses:
     get:
       tags:
         - plugins
@@ -423,7 +423,7 @@
             Client := model.NewAPIv4Client("https://your-mattermost-url.com")
 
             manifests, resp := Client.GetPluginStatuses()
-  /plugins/marketplace:
+  /api/v4/plugins/marketplace:
     post:
       tags:
         - plugins
@@ -565,7 +565,7 @@
             }
 
             ok, resp = Client.GetMarketplacePlugins(filter)
-  /plugins/marketplace/first_admin_visit:
+  /api/v4/plugins/marketplace/first_admin_visit:
     get:
       tags:
         - plugins

--- a/v4/source/posts.yaml
+++ b/v4/source/posts.yaml
@@ -1,4 +1,4 @@
-  /posts:
+  /api/v4/posts:
     post:
       tags:
         - posts
@@ -75,7 +75,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /posts/ephemeral:
+  /api/v4/posts/ephemeral:
     post:
       tags:
         - posts
@@ -142,7 +142,7 @@
             }
 
             createdPost, response := client.CreatePostEphemeral(ephemeralPost)
-  "/posts/{post_id}":
+  "/api/v4/posts/{post_id}":
     get:
       tags:
         - posts
@@ -275,7 +275,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/posts/{post_id}/set_unread":
+  "/api/v4/users/{user_id}/posts/{post_id}/set_unread":
     post:
       tags:
         - posts
@@ -320,7 +320,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/posts/{post_id}/patch":
+  "/api/v4/posts/{post_id}/patch":
     put:
       tags:
         - posts
@@ -379,7 +379,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/thread":
+  "/api/v4/posts/{post_id}/thread":
     get:
       tags:
         - posts
@@ -453,7 +453,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/posts/flagged":
+  "/api/v4/users/{user_id}/posts/flagged":
     get:
       tags:
         - posts
@@ -511,7 +511,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/files/info":
+  "/api/v4/posts/{post_id}/files/info":
     get:
       tags:
         - posts
@@ -553,7 +553,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/channels/{channel_id}/posts":
+  "/api/v4/channels/{channel_id}/posts":
     get:
       tags:
         - posts
@@ -626,7 +626,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/channels/{channel_id}/posts/unread":
+  "/api/v4/users/{user_id}/channels/{channel_id}/posts/unread":
     get:
       tags:
         - posts
@@ -704,7 +704,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/teams/{team_id}/posts/search":
+  "/api/v4/teams/{team_id}/posts/search":
     post:
       tags:
         - posts
@@ -772,7 +772,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/pin":
+  "/api/v4/posts/{post_id}/pin":
     post:
       tags:
         - posts
@@ -804,7 +804,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/unpin":
+  "/api/v4/posts/{post_id}/unpin":
     post:
       tags:
         - posts
@@ -837,7 +837,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/actions/{action_id}":
+  "/api/v4/posts/{post_id}/actions/{action_id}":
     post:
       tags:
         - posts
@@ -876,7 +876,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/ids":
+  "/api/v4/posts/ids":
     post:
       tags:
         - posts
@@ -917,7 +917,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/posts/{post_id}/reminder":
+  "/api/v4/users/{user_id}/posts/{post_id}/reminder":
     post:
       tags:
         - posts
@@ -973,7 +973,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/users/{user_id}/posts/{post_id}/ack":
+  "/api/v4/users/{user_id}/posts/{post_id}/ack":
     post:
       tags:
         - posts

--- a/v4/source/preferences.yaml
+++ b/v4/source/preferences.yaml
@@ -1,4 +1,4 @@
-  "/users/{user_id}/preferences":
+  "/api/v4/users/{user_id}/preferences":
     get:
       tags:
         - preferences
@@ -74,7 +74,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/users/{user_id}/preferences/delete":
+  "/api/v4/users/{user_id}/preferences/delete":
     post:
       tags:
         - preferences
@@ -115,7 +115,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/preferences/{category}":
+  "/api/v4/users/{user_id}/preferences/{category}":
     get:
       tags:
         - preferences
@@ -155,7 +155,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/preferences/{category}/name/{preference_name}":
+  "/api/v4/users/{user_id}/preferences/{category}/name/{preference_name}":
     get:
       tags:
         - preferences

--- a/v4/source/reactions.yaml
+++ b/v4/source/reactions.yaml
@@ -1,4 +1,4 @@
-  /reactions:
+  /api/v4/reactions:
     post:
       tags:
         - reactions
@@ -27,7 +27,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/posts/{post_id}/reactions":
+  "/api/v4/posts/{post_id}/reactions":
     get:
       tags:
         - reactions
@@ -59,7 +59,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/users/{user_id}/posts/{post_id}/reactions/{emoji_name}":
+  "/api/v4/users/{user_id}/posts/{post_id}/reactions/{emoji_name}":
     delete:
       tags:
         - reactions
@@ -101,7 +101,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /posts/ids/reactions:
+  /api/v4/posts/ids/reactions:
     post:
       tags:
         - reactions

--- a/v4/source/roles.yaml
+++ b/v4/source/roles.yaml
@@ -1,4 +1,4 @@
-  "/roles":
+  "/api/v4/roles":
     get:
       tags:
         - roles
@@ -34,7 +34,7 @@
 
             roles, resp := Client.GetAllRoles()
 
-  "/roles/{role_id}":
+  "/api/v4/roles/{role_id}":
     get:
       tags:
         - roles
@@ -73,7 +73,7 @@
             Client.Login("email@domain.com", "Password1")
 
             role, resp := Client.GetRole(<ROLEID>, "")
-  "/roles/name/{role_name}":
+  "/api/v4/roles/name/{role_name}":
     get:
       tags:
         - roles
@@ -112,7 +112,7 @@
             Client.Login("email@domain.com", "Password1")
 
             role, resp := Client.GetRoleByName(<ROLENAME>, "")
-  "/roles/{role_id}/patch":
+  "/api/v4/roles/{role_id}/patch":
     put:
       tags:
         - roles
@@ -165,7 +165,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  /roles/names:
+  /api/v4/roles/names:
     post:
       tags:
         - roles

--- a/v4/source/saml.yaml
+++ b/v4/source/saml.yaml
@@ -1,4 +1,4 @@
-  /saml/metadata:
+  /api/v4/saml/metadata:
     get:
       tags:
         - SAML
@@ -17,7 +17,7 @@
                 type: string
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/metadatafromidp:
+  /api/v4/saml/metadatafromidp:
     post:
       tags:
         - SAML
@@ -45,7 +45,7 @@
                 type: string
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/certificate/idp:
+  /api/v4/saml/certificate/idp:
     post:
       tags:
         - SAML
@@ -112,7 +112,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/certificate/public:
+  /api/v4/saml/certificate/public:
     post:
       tags:
         - SAML
@@ -179,7 +179,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/certificate/private:
+  /api/v4/saml/certificate/private:
     post:
       tags:
         - SAML
@@ -246,7 +246,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/certificate/status:
+  /api/v4/saml/certificate/status:
     get:
       tags:
         - SAML
@@ -270,7 +270,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  /saml/reset_auth_data:
+  /api/v4/saml/reset_auth_data:
     post:
       tags:
         - SAML

--- a/v4/source/schemes.yaml
+++ b/v4/source/schemes.yaml
@@ -1,4 +1,4 @@
-  /schemes:
+  /api/v4/schemes:
     get:
       tags:
         - schemes
@@ -97,7 +97,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/schemes/{scheme_id}":
+  "/api/v4/schemes/{scheme_id}":
     get:
       tags:
         - schemes
@@ -172,7 +172,7 @@
           $ref: "#/components/responses/Forbidden"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/schemes/{scheme_id}/patch":
+  "/api/v4/schemes/{scheme_id}/patch":
     put:
       tags:
         - schemes
@@ -229,7 +229,7 @@
           $ref: "#/components/responses/NotFound"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/schemes/{scheme_id}/teams":
+  "/api/v4/schemes/{scheme_id}/teams":
     get:
       tags:
         - schemes
@@ -284,7 +284,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/schemes/{scheme_id}/channels":
+  "/api/v4/schemes/{scheme_id}/channels":
     get:
       tags:
         - schemes

--- a/v4/source/service_terms.yaml
+++ b/v4/source/service_terms.yaml
@@ -1,4 +1,4 @@
-  /terms_of_service:
+  /api/v4/terms_of_service:
     get:
       tags:
         - terms of service

--- a/v4/source/sharedchannels.yaml
+++ b/v4/source/sharedchannels.yaml
@@ -1,4 +1,4 @@
-  "/sharedchannels/{team_id}":
+  "/api/v4/sharedchannels/{team_id}":
     get:
       tags:
         - shared channels
@@ -62,7 +62,7 @@
               'http://your-mattermost-url.com/api/v4/sharedchannels/4xp9fdt77pncbef59f4k1qe83o' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
 
-  "/sharedchannels/remote_info/{remote_id}":
+  "/api/v4/sharedchannels/remote_info/{remote_id}":
     get:
       tags:
         - shared channels

--- a/v4/source/status.yaml
+++ b/v4/source/status.yaml
@@ -1,4 +1,4 @@
-  "/users/{user_id}/status":
+  "/api/v4/users/{user_id}/status":
     get:
       tags:
         - status
@@ -77,7 +77,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  /users/status/ids:
+  /api/v4/users/status/ids:
     post:
       tags:
         - status
@@ -109,7 +109,7 @@
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  "/users/{user_id}/status/custom":
+  "/api/v4/users/{user_id}/status/custom":
     put:
       tags:
         - status
@@ -180,7 +180,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  "/users/{user_id}/status/custom/recent":
+  "/api/v4/users/{user_id}/status/custom/recent":
     delete:
       tags:
         - status
@@ -229,7 +229,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  "/users/{user_id}/status/custom/recent/delete":
+  "/api/v4/users/{user_id}/status/custom/recent/delete":
     post:
       tags:
         - status

--- a/v4/source/system.yaml
+++ b/v4/source/system.yaml
@@ -1,4 +1,4 @@
-  /system/timezones:
+  /api/v4/system/timezones:
     get:
       tags:
         - system
@@ -21,7 +21,7 @@
                   type: string
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /system/ping:
+  /api/v4/system/ping:
     get:
       tags:
         - system
@@ -86,7 +86,7 @@
 
             // Get server status with database and storage checks
             status, resp = Client.GetPingWithServerStatus()
-  "/system/notices/{teamId}":
+  "/api/v4/system/notices/{teamId}":
     get:
       tags:
         - system
@@ -146,7 +146,7 @@
             Client.Login("email@domain.com", "Password1")
 
             notices, resp := Client.GetNotices(0, teamId, "mobile-android", "1.2.3", "enUS")
-  /system/notices/view:
+  /api/v4/system/notices/view:
     put:
       tags:
         - system
@@ -189,7 +189,7 @@
             notices := []string{"id1","id2"}
             resp := Client.MarkNoticesViewed(notices)
 
-  /database/recycle:
+  /api/v4/database/recycle:
     post:
       tags:
         - system
@@ -220,7 +220,7 @@
             Client.Login("email@domain.com", "Password1")
 
             ok, resp := Client.DatabaseRecycle()
-  /email/test:
+  /api/v4/email/test:
     post:
       tags:
         - system
@@ -272,7 +272,7 @@
 
             // TestEmail
             ok, resp := Client.TestEmail(&config)
-  /site_url/test:
+  /api/v4/site_url/test:
     post:
       tags:
         - system
@@ -326,7 +326,7 @@
 
             // TestSiteURL
             ok, resp := Client.TestSiteURL(siteUrl)
-  /file/s3_test:
+  /api/v4/file/s3_test:
     post:
       tags:
         - system
@@ -381,7 +381,7 @@
 
             // TestS3Connection
             ok, resp := Client.TestS3Connection(&config)
-  /config:
+  /api/v4/config:
     get:
       tags:
         - system
@@ -464,7 +464,7 @@
 
             // UpdateConfig
             updatedConfig, resp := Client.UpdateConfig(config)
-  /config/reload:
+  /api/v4/config/reload:
     post:
       tags:
         - system
@@ -495,7 +495,7 @@
 
             // ReloadConfig
             ok, resp := Client.ReloadConfig()
-  /config/client:
+  /api/v4/config/client:
     get:
       tags:
         - system
@@ -529,7 +529,7 @@
 
             // GetOldClientConfig
             ok, resp := Client.GetOldClientConfig()
-  /config/environment:
+  /api/v4/config/environment:
     get:
       tags:
         - system
@@ -563,7 +563,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /config/patch:
+  /api/v4/config/patch:
     put:
       tags:
         - system
@@ -619,7 +619,7 @@
 
             // UpdateConfig
             updatedConfig, resp := Client.PatchConfig(config)
-  /license:
+  /api/v4/license:
     post:
       tags:
         - system
@@ -702,7 +702,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /license/client:
+  /api/v4/license/client:
     get:
       tags:
         - system
@@ -738,7 +738,7 @@
 
             // GetOldClientLicense
             license, resp := Client.GetOldClientLicense()
-  /license/renewal:
+  /api/v4/license/renewal:
     get:
       tags:
         - system
@@ -767,7 +767,7 @@
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /trial-license:
+  /api/v4/trial-license:
     post:
       tags:
         - system
@@ -813,7 +813,7 @@
 
             // RequestTrialLicense
             resp := Client.RequestTrialLicense()
-  /trial-license/prev:
+  /api/v4/trial-license/prev:
     get:
       tags:
         - system
@@ -836,7 +836,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /audits:
+  /api/v4/audits:
     get:
       tags:
         - system
@@ -883,7 +883,7 @@
 
             // GetAudits
             audits, resp := Client.GetAudits(0, 100, "")
-  /caches/invalidate:
+  /api/v4/caches/invalidate:
     post:
       tags:
         - system
@@ -916,7 +916,7 @@
 
             // InvalidateCaches
             ok, resp := Client.InvalidateCaches()
-  /logs:
+  /api/v4/logs:
     get:
       tags:
         - system
@@ -1020,7 +1020,7 @@
 
             // PostLog
             _, resp := Client.PostLog(message)
-  /analytics/old:
+  /api/v4/analytics/old:
     get:
       tags:
         - system
@@ -1065,7 +1065,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /server_busy:
+  /api/v4/server_busy:
     post:
       tags:
         - system
@@ -1195,7 +1195,7 @@
             curl -X DELETE \
               'http://your-mattermost-url.com/api/v4/server_busy' \
               -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy'
-  /notifications/ack:
+  /api/v4/notifications/ack:
     post:
       tags:
         - root
@@ -1216,7 +1216,7 @@
                 $ref: "#/components/schemas/PushNotification"
         "404":
           $ref: "#/components/responses/NotFound"
-  /redirect_location:
+  /api/v4/redirect_location:
     get:
       tags:
         - system
@@ -1247,7 +1247,7 @@
                     type: string
         "404":
           $ref: "#/components/responses/NotFound"
-  /image:
+  /api/v4/image:
     get:
       tags:
         - system
@@ -1272,7 +1272,7 @@
         "404":
           $ref: "#/components/responses/NotFound"
 
-  /upgrade_to_enterprise:
+  /api/v4/upgrade_to_enterprise:
     post:
       tags:
         - system
@@ -1300,7 +1300,7 @@
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
-  /upgrade_to_enterprise/status:
+  /api/v4/upgrade_to_enterprise/status:
     get:
       tags:
         - system
@@ -1332,7 +1332,7 @@
         "403":
           $ref: "#/components/responses/Forbidden"
 
-  /restart:
+  /api/v4/restart:
     post:
       tags:
         - system
@@ -1357,7 +1357,7 @@
         "403":
           $ref: "#/components/responses/Forbidden"
 
-  /warn_metrics/status:
+  /api/v4/warn_metrics/status:
     get:
       tags:
         - system
@@ -1390,7 +1390,7 @@
         "403":
           $ref: "#/components/responses/Forbidden"
 
-  /warn_metrics/ack/{warn_metric_id}:
+  /api/v4/warn_metrics/ack/{warn_metric_id}:
     post:
       tags:
         - system
@@ -1437,7 +1437,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /warn_metrics/trial-license-ack/{warn_metric_id}:
+  /api/v4/warn_metrics/trial-license-ack/{warn_metric_id}:
     post:
       tags:
         - system
@@ -1472,7 +1472,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /integrity:
+  /api/v4/integrity:
     post:
       tags:
         - system
@@ -1511,7 +1511,7 @@
             Client := model.NewAPIv4SocketClient(socketPath)
 
             ok, resp := Client.CheckIntegrity()
-  /system/support_packet:
+  /api/v4/system/support_packet:
     get:
       tags:
         - system

--- a/v4/source/teams.yaml
+++ b/v4/source/teams.yaml
@@ -1,4 +1,4 @@
-  /teams:
+  /api/v4/teams:
     post:
       tags:
         - teams
@@ -172,7 +172,7 @@
               if ($resp->getStatusCode() == 200) {
                   $teams = json_decode($resp->getBody());
               }
-  "/teams/{team_id}":
+  "/api/v4/teams/{team_id}":
     get:
       tags:
         - teams
@@ -450,7 +450,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/patch":
+  "/api/v4/teams/{team_id}/patch":
     put:
       tags:
         - teams
@@ -548,7 +548,7 @@
             if ($resp->getStatusCode() == 200) {
                 $team = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/privacy":
+  "/api/v4/teams/{team_id}/privacy":
     put:
       tags:
         - teams
@@ -648,7 +648,7 @@
             if ($resp->getStatusCode() == 200) {
                 $updatedTeam = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/restore":
+  "/api/v4/teams/{team_id}/restore":
     post:
       tags:
         - teams
@@ -713,7 +713,7 @@
             if ($resp->getStatusCode() == 200) {
                 $team = json_decode($resp->getBody());
             }
-  "/teams/name/{name}":
+  "/api/v4/teams/name/{name}":
     get:
       tags:
         - teams
@@ -778,7 +778,7 @@
             if ($resp->getStatusCode() == 200) {
                 $team = json_decode($resp->getBody());
             }
-  /teams/search:
+  /api/v4/teams/search:
     post:
       tags:
         - teams
@@ -901,7 +901,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teams = json_decode($resp->getBody())->teams;
             }
-  "/teams/name/{name}/exists":
+  "/api/v4/teams/name/{name}/exists":
     get:
       tags:
         - teams
@@ -962,7 +962,7 @@
             if ($resp->getStatusCode() == 200) {
                 $exists = json_decode($resp->getBody())->exists;
             }
-  "/users/{user_id}/teams":
+  "/api/v4/users/{user_id}/teams":
     get:
       tags:
         - teams
@@ -1031,7 +1031,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teams = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/members":
+  "/api/v4/teams/{team_id}/members":
     get:
       tags:
         - teams
@@ -1202,7 +1202,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teamMember = json_decode($resp->getBody());
             }
-  /teams/members/invite:
+  /api/v4/teams/members/invite:
     post:
       tags:
         - teams
@@ -1274,7 +1274,7 @@
             if ($resp->getStatusCode() == 200) {
                 $tm = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/members/batch":
+  "/api/v4/teams/{team_id}/members/batch":
     post:
       tags:
         - teams
@@ -1375,7 +1375,7 @@
             if ($resp->getStatusCode() == 200) {
                 $tm = json_decode($resp->getBody());
             }
-  "/users/{user_id}/teams/members":
+  "/api/v4/users/{user_id}/teams/members":
     get:
       tags:
         - teams
@@ -1447,7 +1447,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teamMembers = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/members/{user_id}":
+  "/api/v4/teams/{team_id}/members/{user_id}":
     get:
       tags:
         - teams
@@ -1599,7 +1599,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/members/ids":
+  "/api/v4/teams/{team_id}/members/ids":
     post:
       tags:
         - teams
@@ -1690,7 +1690,7 @@
             if ($resp->getStatusCode() == 200) {
                 $tm = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/stats":
+  "/api/v4/teams/{team_id}/stats":
     get:
       tags:
         - teams
@@ -1757,7 +1757,7 @@
             if ($resp->getStatusCode() == 200) {
                 $stats = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/regenerate_invite_id":
+  "/api/v4/teams/{team_id}/regenerate_invite_id":
     post:
       tags:
         - teams
@@ -1824,7 +1824,7 @@
             if ($resp->getStatusCode() == 200) {
                 $team = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/image":
+  "/api/v4/teams/{team_id}/image":
     get:
       tags:
         - teams
@@ -2070,7 +2070,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/members/{user_id}/roles":
+  "/api/v4/teams/{team_id}/members/{user_id}/roles":
     put:
       tags:
         - teams
@@ -2168,7 +2168,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/members/{user_id}/schemeRoles":
+  "/api/v4/teams/{team_id}/members/{user_id}/schemeRoles":
     put:
       tags:
         - teams
@@ -2278,7 +2278,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/teams/unread":
+  "/api/v4/users/{user_id}/teams/unread":
     get:
       tags:
         - teams
@@ -2365,7 +2365,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teams = json_decode($resp->getBody());
             }
-  "/users/{user_id}/teams/{team_id}/unread":
+  "/api/v4/users/{user_id}/teams/{team_id}/unread":
     get:
       tags:
         - teams
@@ -2443,7 +2443,7 @@
             if ($resp->getStatusCode() == 200) {
                 $teamUnread = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/invite/email":
+  "/api/v4/teams/{team_id}/invite/email":
     post:
       tags:
         - teams
@@ -2528,7 +2528,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/invite-guests/email":
+  "/api/v4/teams/{team_id}/invite-guests/email":
     post:
       tags:
         - teams
@@ -2639,7 +2639,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  /teams/invites/email:
+  /api/v4/teams/invites/email:
     delete:
       tags:
         - teams
@@ -2696,7 +2696,7 @@
             if ($resp->getStatusCode() == 200) {
                 $ok = json_decode($resp->getBody())->status;
             }
-  "/teams/{team_id}/import":
+  "/api/v4/teams/{team_id}/import":
     post:
       tags:
         - teams
@@ -2817,7 +2817,7 @@
             if ($resp->getStatusCode() == 200) {
                 $fileResp = json_decode($resp->getBody())->results;
             }
-  "/teams/invite/{invite_id}":
+  "/api/v4/teams/invite/{invite_id}":
     get:
       tags:
         - teams
@@ -2893,7 +2893,7 @@
             if ($resp->getStatusCode() == 200) {
                 $team = json_decode($resp->getBody());
             }
-  "/teams/{team_id}/scheme":
+  "/api/v4/teams/{team_id}/scheme":
     put:
       tags:
         - teams
@@ -2991,7 +2991,7 @@
               -H 'Authorization: Bearer frn8fu5rtpyc5m4xy6q3oj4yur' \
               -H 'Content-Type: application/json' \
               -d '{"scheme_id": "qjda3stwafbgpqjaxej3k76sga"}'
-  "/teams/{team_id}/members_minus_group_members":
+  "/api/v4/teams/{team_id}/members_minus_group_members":
     get:
       tags:
         - teams

--- a/v4/source/uploads.yaml
+++ b/v4/source/uploads.yaml
@@ -1,4 +1,4 @@
-  "/uploads":
+  "/api/v4/uploads":
     post:
       tags:
         - uploads
@@ -75,7 +75,7 @@
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
             -H 'Content-Type: application/json' \
             --data-binary '{"channel_id": "4i6jn8r483nnuqnibnmgz8jo4o", "filename": "test.png", "file_size": 512000}'
-  "/uploads/{upload_id}":
+  "/api/v4/uploads/{upload_id}":
     get:
       tags:
         - uploads

--- a/v4/source/usage.yaml
+++ b/v4/source/usage.yaml
@@ -1,4 +1,4 @@
-  /usage/posts:
+  /api/v4/usage/posts:
     get:
       tags:
         - usage
@@ -24,7 +24,7 @@
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /usage/storage:
+  /api/v4/usage/storage:
     get:
       tags:
         - usage

--- a/v4/source/users.yaml
+++ b/v4/source/users.yaml
@@ -1,4 +1,4 @@
-  /users/login:
+  /api/v4/users/login:
     post:
       tags:
         - users
@@ -40,7 +40,7 @@
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/login/cws:
+  /api/v4/users/login/cws:
     post:
       tags:
         - users
@@ -74,7 +74,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  /users/logout:
+  /api/v4/users/logout:
     post:
       tags:
         - users
@@ -96,7 +96,7 @@
         "403":
           $ref: "#/components/responses/Forbidden"
 
-  /users:
+  /api/v4/users:
     post:
       tags:
         - users
@@ -504,7 +504,7 @@
             Client.HttpClient = &http.Client{Transport: tr}
 
             ok, resp := Client.PermanentDeleteAllUsers()
-  /users/ids:
+  /api/v4/users/ids:
     post:
       tags:
         - users
@@ -547,7 +547,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  /users/group_channels:
+  /api/v4/users/group_channels:
     post:
       tags:
         - users
@@ -589,7 +589,7 @@
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  /users/usernames:
+  /api/v4/users/usernames:
     post:
       tags:
         - users
@@ -658,7 +658,7 @@
             if ($resp->getStatusCode() == 200) {
                 $users = json_decode($resp->getBody());
             }
-  /users/search:
+  /api/v4/users/search:
     post:
       tags:
         - users
@@ -799,7 +799,7 @@
             if ($resp->getStatusCode() == 200) {
                 $users = json_decode($resp->getBody());
             }
-  /users/autocomplete:
+  /api/v4/users/autocomplete:
     get:
       tags:
         - users
@@ -903,7 +903,7 @@
             if ($resp->getStatusCode() == 200) {
                 $users = json_decode($resp->getBody());
             }
-  /users/known:
+  /api/v4/users/known:
     get:
       tags:
         - users
@@ -937,7 +937,7 @@
 
             userIds, resp := Client.GetKnownUsers()
 
-  /users/stats:
+  /api/v4/users/stats:
     get:
       tags:
         - users
@@ -993,7 +993,7 @@
             if ($resp->getStatusCode() == 200) {
                 $stats = json_decode($resp->getBody())->total_users_count;
             }
-  /users/stats/filtered:
+  /api/v4/users/stats/filtered:
     get:
       tags:
         - users
@@ -1069,7 +1069,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/users/{user_id}":
+  "/api/v4/users/{user_id}":
     get:
       tags:
         - users
@@ -1352,7 +1352,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/patch":
+  "/api/v4/users/{user_id}/patch":
     put:
       tags:
         - users
@@ -1481,7 +1481,7 @@
             if ($resp->getStatusCode() == 200) {
                $user = json_decode($resp->getBody());
             }
-  "/users/{user_id}/roles":
+  "/api/v4/users/{user_id}/roles":
     put:
       tags:
         - users
@@ -1566,7 +1566,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/active":
+  "/api/v4/users/{user_id}/active":
     put:
       tags:
         - users
@@ -1652,7 +1652,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/image":
+  "/api/v4/users/{user_id}/image":
     get:
       tags:
         - users
@@ -1905,7 +1905,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody()->status;
             }
-  "/users/{user_id}/image/default":
+  "/api/v4/users/{user_id}/image/default":
     get:
       tags:
         - users
@@ -1975,7 +1975,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody();
             }
-  "/users/username/{username}":
+  "/api/v4/users/username/{username}":
     get:
       tags:
         - users
@@ -2043,7 +2043,7 @@
             if ($resp->getStatusCode() == 200) {
                $user = json_decode($resp->getBody());
             }
-  /users/password/reset:
+  /api/v4/users/password/reset:
     post:
       tags:
         - users
@@ -2125,7 +2125,7 @@
             if ($resp->getStatusCode() == 200) {
                $success = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/mfa":
+  "/api/v4/users/{user_id}/mfa":
     put:
       tags:
         - users
@@ -2217,7 +2217,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody()->status;
             }
-  "/users/{user_id}/mfa/generate":
+  "/api/v4/users/{user_id}/mfa/generate":
     post:
       tags:
         - users
@@ -2296,7 +2296,7 @@
             if ($resp->getStatusCode() == 200) {
                $mfaSecret = json_decode($resp->getBody());
             }
-  "/users/{user_id}/demote":
+  "/api/v4/users/{user_id}/demote":
     post:
       tags:
         - users
@@ -2370,7 +2370,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody()->status;
             }
-  "/users/{user_id}/promote":
+  "/api/v4/users/{user_id}/promote":
     post:
       tags:
         - users
@@ -2444,7 +2444,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody()->status;
             }
-  "/users/{user_id}/convert_to_bot":
+  "/api/v4/users/{user_id}/convert_to_bot":
     post:
       tags:
         - bots
@@ -2490,7 +2490,7 @@
             userId := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
 
             bot, resp := Client.ConvertUserToBot(userId)
-  /users/mfa:
+  /api/v4/users/mfa:
     post:
       tags:
         - users
@@ -2565,7 +2565,7 @@
             if ($resp->getStatusCode() == 200) {
                $required = json_decode($resp->getBody())->mfa_required;
             }
-  "/users/{user_id}/password":
+  "/api/v4/users/{user_id}/password":
     put:
       tags:
         - users
@@ -2662,7 +2662,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  /users/password/reset/send:
+  /api/v4/users/password/reset/send:
     post:
       tags:
         - users
@@ -2737,7 +2737,7 @@
             if ($resp->getStatusCode() == 200) {
                $pass = json_decode($resp->getBody())->status;
             }
-  "/users/email/{email}":
+  "/api/v4/users/email/{email}":
     get:
       tags:
         - users
@@ -2807,7 +2807,7 @@
             if ($resp->getStatusCode() == 200) {
                $user = json_decode($resp->getBody());
             }
-  "/users/{user_id}/sessions":
+  "/api/v4/users/{user_id}/sessions":
     get:
       tags:
         - users
@@ -2877,7 +2877,7 @@
             if ($resp->getStatusCode() == 200) {
                $sessions = json_decode($resp->getBody());
             }
-  "/users/{user_id}/sessions/revoke":
+  "/api/v4/users/{user_id}/sessions/revoke":
     post:
       tags:
         - users
@@ -2960,7 +2960,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/sessions/revoke/all":
+  "/api/v4/users/{user_id}/sessions/revoke/all":
     post:
       tags:
         - users
@@ -3030,7 +3030,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  /users/sessions/device:
+  /api/v4/users/sessions/device:
     put:
       tags:
         - users
@@ -3104,7 +3104,7 @@
             if ($resp->getStatusCode() == 200) {
                $pass = json_decode($resp->getBody())->status;
             }
-  "/users/{user_id}/audits":
+  "/api/v4/users/{user_id}/audits":
     get:
       tags:
         - users
@@ -3171,7 +3171,7 @@
             if ($resp->getStatusCode() == 200) {
                $audits = json_decode($resp->getBody());
             }
-  "/users/{user_id}/email/verify/member":
+  "/api/v4/users/{user_id}/email/verify/member":
     post:
       tags:
         - users
@@ -3216,7 +3216,7 @@
             userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u
 
             user, resp := Client.VerifyUserEmailWithoutToken(userID)
-  /users/email/verify:
+  /api/v4/users/email/verify:
     post:
       tags:
         - users
@@ -3283,7 +3283,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  /users/email/verify/send:
+  /api/v4/users/email/verify/send:
     post:
       tags:
         - users
@@ -3354,7 +3354,7 @@
             if ($resp->getStatusCode() == 200) {
                $pass = json_decode($resp->getBody())->status;
             }
-  /users/login/switch:
+  /api/v4/users/login/switch:
     post:
       tags:
         - users
@@ -3495,7 +3495,7 @@
             if ($resp->getStatusCode() == 200) {
                $link = json_decode($resp->getBody())->follow_link;
             }
-  "/users/{user_id}/tokens":
+  "/api/v4/users/{user_id}/tokens":
     post:
       tags:
         - users
@@ -3673,7 +3673,7 @@
             if ($resp->getStatusCode() == 200) {
                $tokens = json_decode($resp->getBody());
             }
-  /users/tokens:
+  /api/v4/users/tokens:
     get:
       tags:
         - users
@@ -3728,7 +3728,7 @@
             Client.Login("email@domain.com", "Password1")
 
             tokens, resp := Client.GetUserAccessTokens(0, 100)
-  /users/tokens/revoke:
+  /api/v4/users/tokens/revoke:
     post:
       tags:
         - users
@@ -3806,7 +3806,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  "/users/tokens/{token_id}":
+  "/api/v4/users/tokens/{token_id}":
     get:
       tags:
         - users
@@ -3880,7 +3880,7 @@
             if ($resp->getStatusCode() == 200) {
                $token = json_decode($resp->getBody());
             }
-  /users/tokens/disable:
+  /api/v4/users/tokens/disable:
     post:
       tags:
         - users
@@ -3959,7 +3959,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  /users/tokens/enable:
+  /api/v4/users/tokens/enable:
     post:
       tags:
         - users
@@ -4037,7 +4037,7 @@
             if ($resp->getStatusCode() == 200) {
                $ok = json_decode($resp->getBody())->status;
             }
-  /users/tokens/search:
+  /api/v4/users/tokens/search:
     post:
       tags:
         - users
@@ -4118,7 +4118,7 @@
             if ($resp->getStatusCode() == 200) {
                $userAccessTokens = json_decode($resp->getBody());
             }
-  "/users/{user_id}/auth":
+  "/api/v4/users/{user_id}/auth":
     put:
       tags:
         - users
@@ -4212,7 +4212,7 @@
             if ($resp->getStatusCode() == 200) {
                $user = json_decode($resp->getBody());
             }
-  "/users/{user_id}/terms_of_service":
+  "/api/v4/users/{user_id}/terms_of_service":
     post:
       tags:
         - users
@@ -4339,7 +4339,7 @@
             userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
 
             userTermsOfService, resp := Client.GetUserTermsOfService(userID, "")
-  /users/sessions/revoke/all:
+  /api/v4/users/sessions/revoke/all:
     post:
       tags:
         - users
@@ -4375,7 +4375,7 @@
 
             response, err := Client.RevokeSessionsFromAllUsers()
 
-  "/users/{user_id}/typing":
+  "/api/v4/users/{user_id}/typing":
     post:
       tags:
         - users
@@ -4433,7 +4433,7 @@
                 ParentId: "post_id",
             })
 
-  "/users/{user_id}/uploads":
+  "/api/v4/users/{user_id}/uploads":
     get:
       tags:
         - users
@@ -4484,7 +4484,7 @@
             curl 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/uploads' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
 
-  "/users/{user_id}/channel_members":
+  "/api/v4/users/{user_id}/channel_members":
     get:
       tags:
         - users
@@ -4547,7 +4547,7 @@
             curl 'http://localhost:8065/api/v4/users/me/channel_members?page=0&per_page=2' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
 
-  /users/migrate_auth/ldap:
+  /api/v4/users/migrate_auth/ldap:
     post:
       tags:
         - users
@@ -4605,7 +4605,7 @@
 
             ok, response := Client.MigrateAuthToLdap(fromAuthService, matchField, force)
 
-  /users/migrate_auth/saml:
+  /api/v4/users/migrate_auth/saml:
       post:
         tags:
           - users
@@ -4663,7 +4663,7 @@
 
               ok, response := Client.MigrateAuthToSaml(fromAuthService, usersMap, auto)
 
-  "/users/{user_id}/teams/{team_id}/threads":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads":
    get:
     tags:
      - threads
@@ -4770,7 +4770,7 @@
           curl 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads' \
           -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
 
-  "/users/{user_id}/teams/{team_id}/threads/mention_counts":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/mention_counts":
     get:
       tags:
         - threads
@@ -4820,7 +4820,7 @@
         source: |
           curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/mention_counts' \
           -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \          
-  "/users/{user_id}/teams/{team_id}/threads/read":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/read":
     put:
       tags:
         - threads
@@ -4870,7 +4870,7 @@
         source: |
           curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/read' \
           -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}/read/{timestamp}":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/read/{timestamp}":
     put:
       tags:
         - threads
@@ -4932,7 +4932,7 @@
           source: |
             curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/read' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' 
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}/set_unread/{post_id}":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/set_unread/{post_id}":
     put:
       tags:
         - threads
@@ -4996,7 +4996,7 @@
           source: |
             curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/teams/fc6su111111pmhrb9c967paxe/threads/f96cv0897624352346e/set_unread' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' 
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}/following":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/following":
     put:
       tags:
         - threads
@@ -5107,7 +5107,7 @@
           source: |
             curl -X DELETE 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/following' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/teams/{team_id}/threads/{thread_id}":
+  "/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}":
     get:
       tags:
         - threads
@@ -5163,7 +5163,7 @@
           source: |
             curl -X GET 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624' \
             -H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \
-  "/users/{user_id}/data_retention/team_policies":
+  "/api/v4/users/{user_id}/data_retention/team_policies":
     get:
       tags:
         - data retention
@@ -5213,7 +5213,7 @@
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplemented"
-  "/users/{user_id}/data_retention/channel_policies":
+  "/api/v4/users/{user_id}/data_retention/channel_policies":
     get:
       tags:
         - data retention

--- a/v4/source/webhooks.yaml
+++ b/v4/source/webhooks.yaml
@@ -1,4 +1,4 @@
-  /hooks/incoming:
+  /api/v4/hooks/incoming:
     post:
       tags:
         - webhooks
@@ -98,7 +98,7 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  "/hooks/incoming/{hook_id}":
+  "/api/v4/hooks/incoming/{hook_id}":
     get:
       tags:
         - webhooks
@@ -231,7 +231,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  /hooks/outgoing:
+  /api/v4/hooks/outgoing:
     post:
       tags:
         - webhooks
@@ -359,7 +359,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/hooks/outgoing/{hook_id}":
+  "/api/v4/hooks/outgoing/{hook_id}":
     get:
       tags:
         - webhooks
@@ -485,7 +485,7 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/hooks/outgoing/{hook_id}/regen_token":
+  "/api/v4/hooks/outgoing/{hook_id}/regen_token":
     post:
       tags:
         - webhooks


### PR DESCRIPTION
#### Summary
Switch to prefixing `/api/v4` explicitly on all API paths, allowing the dynamically pulled in Playbooks API to anchor itself at `/plugins/playbooks/api/v0` without ambiguity. Even without the Playbooks, this anchor allows us to more easily distinguish a potential `/api/v5` in the future.

Before:

<img width="634" alt="image" src="https://user-images.githubusercontent.com/1023171/232557695-67cfedb2-7177-46e8-a60d-d4debba60371.png">
<img width="618" alt="image" src="https://user-images.githubusercontent.com/1023171/232557746-d10e6009-79f1-436a-8242-bc4bc9455ffb.png">

After:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/1023171/232558067-c88fa51f-4a02-4a1d-9edd-5dbb0aed8a42.png">
<img width="626" alt="image" src="https://user-images.githubusercontent.com/1023171/232557899-77880385-5df0-4467-9a94-4bfb02689dd6.png">


#### Ticket Link
None, but see https://github.com/mattermost/mattermost-server/pull/22989.