### PR TITLE
updated client paths

### DIFF
--- a/v4/source/introduction.yaml
+++ b/v4/source/introduction.yaml
@@ -59,7 +59,7 @@ tags:
 
       * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.ts)
 
-      * [Mattermost Golang Driver](https://github.com/mattermost/mattermost-server/blob/master/model/client4.go)
+      * [Mattermost Golang Driver](https://github.com/mattermost/mattermost/blob/master/server/public/model/client4.go)
 
 
       #### Community-built Drivers


### PR DESCRIPTION
#### Summary
Thanks to a [community member report](https://github.com/mattermost/mattermost/pull/23345#issuecomment-1563798237) for spotting that the permalinks to our Go client stopped working with the submodule update. 

The redux link for the JavaScript driver is super old, but I'm not aware of a replacement, so I left it untouched.

#### Ticket Link
None.